### PR TITLE
Update config.example.json

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,152 +1,119 @@
 {
-  "global-options":{
-    "alz-minimum-version":"v2.3.1",
-    "central-log-retention":730,
-    "zones":{
-      "account":"shared-network",
-      "resolver-vpc":"Endpoint",
-      "names":{
-        "public":[
-          "dept.cloud-nuage.canada.ca"
-        ],
-        "private":[
-          "dept.cloud-nuage.gc.ca"
-        ]
+  "global-options": {
+    "alz-minimum-version": "v2.3.1",
+    "central-log-retention": 730,
+    "zones": {
+      "account": "shared-network",
+      "resolver-vpc": "Endpoint",
+      "names": {
+        "public": ["dept.cloud-nuage.canada.ca"],
+        "private": ["dept.cloud-nuage.gc.ca"]
       }
     },
-    "security-hub-frameworks":{
-      "enable-aws-foundational":true,
-      "foundation-controls-to-disable":[
-        "IAM.1"
-      ],
-      "enable-cis-foundations":true,
-      "cis-foundations-controls-to-disable":[
-        "CIS1.3",
-        "CIS1.11"
-      ],
-      "enable-pci-dss":true,
-      "pci-dss-controls-to-disable":[
-        "PCI.IAM.3",
-        "PCIDSS8.3.1"
-      ]
+    "security-hub-frameworks": {
+      "enable-aws-foundational": true,
+      "foundation-controls-to-disable": ["IAM.1"],
+      "enable-cis-foundations": true,
+      "cis-foundations-controls-to-disable": ["CIS1.3", "CIS1.11"],
+      "enable-pci-dss": true,
+      "pci-dss-controls-to-disable": ["PCI.IAM.3", "PCIDSS8.3.1"]
     },
-    "scps":{
-      "ALZ-Core":"/SCPs/aws-landing-zone-core-mandatory-preventive-guardrails-modifiedAccel.json",
-      "ALZ-Non-Core":"/SCPs/aws-landing-zone-core-mandatory-preventive-guardrails-modifiedAccel.json",
-      "Guardrails-Part1":"/SCPs/PBMMAccel-Guardrails-Part1.json",
-      "Guardrails-Part2":"/SCPs/PBMMAccel-Guardrails-Part2.json",
-      "Guardrails-PBMM-Only":"/SCPs/PBMMAccel-Guardrails-PBMM-Only.json",
-      "Guardrails-Unclass-Only":"/SCPs/PBMMAccel-Guardrails-Unclass-Only.json",
-      "Quarantine-Deny-All":"/SCPs/Quarantine-Deny-All.json"
+    "scps": {
+      "ALZ-Core": "/SCPs/aws-landing-zone-core-mandatory-preventive-guardrails-modifiedAccel.json",
+      "ALZ-Non-Core": "/SCPs/aws-landing-zone-core-mandatory-preventive-guardrails-modifiedAccel.json",
+      "Guardrails-Part1": "/SCPs/PBMMAccel-Guardrails-Part1.json",
+      "Guardrails-Part2": "/SCPs/PBMMAccel-Guardrails-Part2.json",
+      "Guardrails-PBMM-Only": "/SCPs/PBMMAccel-Guardrails-PBMM-Only.json",
+      "Guardrails-Unclass-Only": "/SCPs/PBMMAccel-Guardrails-Unclass-Only.json",
+      "Quarantine-Deny-All": "/SCPs/Quarantine-Deny-All.json"
     },
-    "on-prem":{
-      "cidr":[
-        "7.0.0.0/8",
-        "10.0.0.0/8"
-      ]
+    "on-prem": {
+      "cidr": ["7.0.0.0/8", "10.0.0.0/8"]
     }
   },
-  "mandatory-account-configs":{
-    "shared-network":{
-      "account-name":"SharedNetwork",
-      "email":"bmycroft+lzT-network@amazon.com",
-      "ou":"core",
-      "share-mad-from":"operations",
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+  "mandatory-account-configs": {
+    "shared-network": {
+      "account-name": "SharedNetwork",
+      "email": "bmycroft+lzT-network@amazon.com",
+      "ou": "core",
+      "share-mad-from": "operations",
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           }
         ]
       },
-      "limits":{
-        "Amazon VPC/Interface VPC endpoints per VPC":200,
-        "Amazon VPC/VPCs per Region":15,
-        "AWS CloudFormation/Stack count":400,
-        "AWS CloudFormation/Stack sets per administrator account":400
+      "limits": {
+        "Amazon VPC/Interface VPC endpoints per VPC": 200,
+        "Amazon VPC/VPCs per Region": 15,
+        "AWS CloudFormation/Stack count": 400,
+        "AWS CloudFormation/Stack sets per administrator account": 400
       },
-      "vpc":{
-        "deploy":"local",
-        "name":"Endpoint",
-        "cidr":"10.7.0.0/22",
-        "region":"ca-central-1",
-        "use-central-endpoints":false,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+      "vpc": {
+        "deploy": "local",
+        "name": "Endpoint",
+        "cidr": "10.7.0.0/22",
+        "region": "ca-central-1",
+        "use-central-endpoints": false,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"Endpoint",
-            "definitions":[
+            "name": "Endpoint",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"EndpointVPC_Common",
-                "cidr":"10.7.0.0/24"
+                "az": "a",
+                "route-table": "EndpointVPC_Common",
+                "cidr": "10.7.0.0/24"
               },
               {
-                "az":"b",
-                "route-table":"EndpointVPC_Common",
-                "cidr":"10.7.1.0/24"
+                "az": "b",
+                "route-table": "EndpointVPC_Common",
+                "cidr": "10.7.1.0/24"
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-
-        ],
-        "route-tables":[
+        "gateway-endpoints": [],
+        "route-tables": [
           {
-            "name":"EndpointVPC_Common"
+            "name": "EndpointVPC_Common"
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"local",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "core"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "segregated",
-            "shared",
-            "standalone"
-          ],
-          "blackhole-route":false,
-          "attach-subnets":[
-            "Endpoint"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "local",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["core"],
+          "tgw-rt-propagate": ["core", "segregated", "shared", "standalone"],
+          "blackhole-route": false,
+          "attach-subnets": ["Endpoint"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":{
-          "subnet":"Endpoint",
-          "endpoints":[
+        "interface-endpoints": {
+          "subnet": "Endpoint",
+          "endpoints": [
             "access-analyzer",
             "application-autoscaling",
             "appmesh-envoy-management",
@@ -200,2300 +167,1912 @@
             "states"
           ]
         },
-        "resolvers":{
-          "subnet":"Endpoint",
-          "outbound":true,
-          "inbound":true
+        "resolvers": {
+          "subnet": "Endpoint",
+          "outbound": true,
+          "inbound": true
         },
-        "on-premise-rules":[
+        "on-premise-rules": [
           {
-            "zone":"dept.gc.ca",
-            "outbound-ips":[
-              "7.23.0.1",
-              "7.26.0.2"
-            ]
+            "zone": "dept.gc.ca",
+            "outbound-ips": ["7.23.0.1", "7.26.0.2"]
           },
           {
-            "zone":"test.ca",
-            "outbound-ips":[
-              "7.23.0.1",
-              "7.26.0.2"
-            ]
+            "zone": "test.ca",
+            "outbound-ips": ["7.23.0.1", "7.26.0.2"]
           }
         ]
       },
-      "deployments":{
-        "tgw":{
-          "name":"Main",
-          "asn":64512,
-          "features":{
-            "DNS-support":true,
-            "VPN-ECMP-support":true,
-            "Default-route-table-association":false,
-            "Default-route-table-propagation":false,
-            "Auto-accept-sharing-attachments":false
+      "deployments": {
+        "tgw": {
+          "name": "Main",
+          "asn": 64512,
+          "features": {
+            "DNS-support": true,
+            "VPN-ECMP-support": true,
+            "Default-route-table-association": false,
+            "Default-route-table-propagation": false,
+            "Auto-accept-sharing-attachments": false
           },
-          "route-tables":[
-            "core",
-            "segregated",
-            "shared",
-            "standalone"
-          ]
+          "route-tables": ["core", "segregated", "shared", "standalone"]
         }
       }
     },
-    "operations":{
-      "account-name":"Operations",
-      "email":"bmycroft+lzT-operations@amazon.com",
-      "ou":"core",
-      "limits":{
-
-      },
-      "share-mad-from":"",
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+    "operations": {
+      "account-name": "Operations",
+      "email": "bmycroft+lzT-operations@amazon.com",
+      "ou": "core",
+      "limits": {},
+      "share-mad-from": "",
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       },
-      "deployments":{
-        "mad":{
-          "dir-id":1001,
-          "deploy":true,
-          "vpc-name":"Central",
-          "region":"ca-central-1",
-          "subnet":"GCWide",
-          "size":"Enterprise",
-          "dns-domain":"brian.local",
-          "netbios-domain":"brian",
-          "central-resolver-rule-account":"shared-network",
-          "central-resolver-rule-vpc":"Endpoint",
-          "log-group-name":"PBMMAccel-MAD-brian-local-LG",
-          "share-to-master":true,
-          "restrict_srcips":[
-            "100.96.252.0/23",
-            "100.96.100.0/23",
-            "7.0.0.0/8",
-            "10.0.0.0/8"
-          ],
-          "num-rdgw-hosts":1,
-          "RDGWInstanceType":"t2.large",
-          "password-policies":{
-            "history":24,
-            "max-age":90,
-            "min-age":1,
-            "min-len":12,
-            "complexity":true,
-            "reversible":false,
-            "failed-attaempts":6,
-            "lockout-duration":30,
-            "lockout-attempts-reset":30
+      "deployments": {
+        "mad": {
+          "dir-id": 1001,
+          "deploy": true,
+          "vpc-name": "Central",
+          "region": "ca-central-1",
+          "subnet": "GCWide",
+          "size": "Enterprise",
+          "dns-domain": "brian.local",
+          "netbios-domain": "brian",
+          "central-resolver-rule-account": "shared-network",
+          "central-resolver-rule-vpc": "Endpoint",
+          "log-group-name": "PBMMAccel-MAD-brian-local-LG",
+          "share-to-master": true,
+          "restrict_srcips": ["100.96.252.0/23", "100.96.100.0/23", "7.0.0.0/8", "10.0.0.0/8"],
+          "num-rdgw-hosts": 1,
+          "RDGWInstanceType": "t2.large",
+          "password-policies": {
+            "history": 24,
+            "max-age": 90,
+            "min-age": 1,
+            "min-len": 12,
+            "complexity": true,
+            "reversible": false,
+            "failed-attaempts": 6,
+            "lockout-duration": 30,
+            "lockout-attempts-reset": 30
           },
-          "ad-groups":[
-            "Provisioning"
-          ],
-          "ad-per-account-groups":[
-            "-Admins",
-            "-PowerUser",
-            "-View"
-          ],
-          "adc-group":"ADConnector",
-          "ad-users":[
+          "ad-groups": ["Provisioning"],
+          "ad-per-account-groups": ["-Admins", "-PowerUser", "-View"],
+          "adc-group": "ADConnector",
+          "ad-users": [
             {
-              "user":"adconnector",
-              "groups":[
-                "ADConnector"
-              ]
+              "user": "adconnector",
+              "groups": ["ADConnector"]
             },
             {
-              "user":"Brian",
-              "groups":[
-                "Provisioning",
-                "*-View",
-                "*-Admin",
-                "*-PowerUsers",
-                "AWS Delegated Administrators"
-              ]
+              "user": "Brian",
+              "groups": ["Provisioning", "*-View", "*-Admin", "*-PowerUsers", "AWS Delegated Administrators"]
             },
             {
-              "user":"TestUser",
-              "groups":[
-                "*-View"
-              ]
+              "user": "TestUser",
+              "groups": ["*-View"]
             }
           ]
         },
-        "ops-dashboard":{
-          "deploy":true
+        "ops-dashboard": {
+          "deploy": true
         },
-        "syslog":{
-          "deploy":true
+        "syslog": {
+          "deploy": true
         },
-        "rdweb-pwd":{
-          "deploy":true,
-          "restrict_srcips":[
-            "7.0.0.0/8",
-            "10.0.0.0/8"
-          ]
+        "rdweb-pwd": {
+          "deploy": true,
+          "restrict_srcips": ["7.0.0.0/8", "10.0.0.0/8"]
         }
       }
     },
-    "perimeter":{
-      "account-name":"Perimeter",
-      "email":"bmycroft+lzT-perimeter@amazon.com",
-      "ou":"core",
-      "limits":{
-
-      },
-      "share-mad-from":"",
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+    "perimeter": {
+      "account-name": "Perimeter",
+      "email": "bmycroft+lzT-perimeter@amazon.com",
+      "ou": "core",
+      "limits": {},
+      "share-mad-from": "",
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           },
           {
-            "Policy-Name":"Fortigate-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/Fortigate-policy.txt"
+            "Policy-Name": "Fortigate-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/Fortigate-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Forigate-Role",
-            "Type":"EC2",
-            "Policies":[
-              "Fortigate-Policy"
-            ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Forigate-Role",
+            "Type": "EC2",
+            "Policies": ["Fortigate-Policy"],
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       },
-      "vpc":{
-        "deploy":"local",
-        "name":"Perimeter",
-        "cidr":"100.96.250.0/23",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":true,
-        "vgw":{
-          "asn":65534
+      "vpc": {
+        "deploy": "local",
+        "name": "Perimeter",
+        "cidr": "100.96.250.0/23",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": true,
+        "vgw": {
+          "asn": 65534
         },
-        "pcx":false,
-        "natgw":{
-          "subnet":{
-            "name":"Public",
-            "az":"a"
+        "pcx": false,
+        "natgw": {
+          "subnet": {
+            "name": "Public",
+            "az": "a"
           }
         },
-        "subnets":[
+        "subnets": [
           {
-            "name":"Public",
-            "definitions":[
+            "name": "Public",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"Public_Shared",
-                "cidr":"100.96.251.64/26"
+                "az": "a",
+                "route-table": "Public_Shared",
+                "cidr": "100.96.251.64/26"
               },
               {
-                "az":"b",
-                "route-table":"Public_Shared",
-                "cidr":"100.96.251.128/26"
+                "az": "b",
+                "route-table": "Public_Shared",
+                "cidr": "100.96.251.128/26"
               }
             ]
           },
           {
-            "name":"FWMgmt",
-            "definitions":[
+            "name": "FWMgmt",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"FWMgmt_azA",
-                "cidr":"100.96.251.16/28"
+                "az": "a",
+                "route-table": "FWMgmt_azA",
+                "cidr": "100.96.251.16/28"
               },
               {
-                "az":"b",
-                "route-table":"FWMgmt_azB",
-                "cidr":"100.96.251.48/28"
+                "az": "b",
+                "route-table": "FWMgmt_azB",
+                "cidr": "100.96.251.48/28"
               }
             ]
           },
           {
-            "name":"Proxy",
-            "definitions":[
+            "name": "Proxy",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"Proxy_azA",
-                "cidr":"100.96.250.0/25"
+                "az": "a",
+                "route-table": "Proxy_azA",
+                "cidr": "100.96.250.0/25"
               },
               {
-                "az":"b",
-                "route-table":"Proxy_azB",
-                "cidr":"100.96.250.128/25"
+                "az": "b",
+                "route-table": "Proxy_azB",
+                "cidr": "100.96.250.128/25"
               }
             ]
           },
           {
-            "name":"OnPremise",
-            "definitions":[
+            "name": "OnPremise",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"OnPremise_Shared",
-                "cidr":"100.96.251.0/28"
+                "az": "a",
+                "route-table": "OnPremise_Shared",
+                "cidr": "100.96.251.0/28"
               },
               {
-                "az":"b",
-                "route-table":"OnPremise_Shared",
-                "cidr":"100.96.251.32/28"
-              }
-            ]
-          }
-        ],
-        "gateway-endpoints":[
-          "s3"
-        ],
-        "route-tables":[
-          {
-            "name":"OnPremise_Shared"
-          },
-          {
-            "name":"Public_Shared",
-            "routes":[
-              {
-                "destination":"0.0.0.0/0",
-                "target":"IGW"
-              }
-            ]
-          },
-          {
-            "name":"FWMgmt_azA",
-            "routes":[
-              {
-                "destination":"7.0.0.0/8",
-                "target":"VGW"
-              },
-              {
-                "destination":"0.0.0.0/0",
-                "target":"ENI-FW-az1-p2"
-              },
-              {
-                "destination":"s3",
-                "target":"s3"
-              }
-            ]
-          },
-          {
-            "name":"FWMgmt_azB",
-            "routes":[
-              {
-                "destination":"7.0.0.0/8",
-                "target":"VGW"
-              },
-              {
-                "destination":"0.0.0.0/0",
-                "target":"ENI-FW-az2-p2"
-              },
-              {
-                "destination":"s3",
-                "target":"s3"
-              }
-            ]
-          },
-          {
-            "name":"Proxy_azA",
-            "routes":[
-              {
-                "destination":"0.0.0.0/0",
-                "target":"ENI-FW-az1-p4"
-              }
-            ]
-          },
-          {
-            "name":"Proxy_azB",
-            "routes":[
-              {
-                "destination":"0.0.0.0/0",
-                "target":"ENI-FW-az2-p4"
+                "az": "b",
+                "route-table": "OnPremise_Shared",
+                "cidr": "100.96.251.32/28"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":false
+        "gateway-endpoints": ["s3"],
+        "route-tables": [
+          {
+            "name": "OnPremise_Shared"
+          },
+          {
+            "name": "Public_Shared",
+            "routes": [
+              {
+                "destination": "0.0.0.0/0",
+                "target": "IGW"
+              }
+            ]
+          },
+          {
+            "name": "FWMgmt_azA",
+            "routes": [
+              {
+                "destination": "7.0.0.0/8",
+                "target": "VGW"
+              },
+              {
+                "destination": "0.0.0.0/0",
+                "target": "ENI-FW-az1-p2"
+              },
+              {
+                "destination": "s3",
+                "target": "s3"
+              }
+            ]
+          },
+          {
+            "name": "FWMgmt_azB",
+            "routes": [
+              {
+                "destination": "7.0.0.0/8",
+                "target": "VGW"
+              },
+              {
+                "destination": "0.0.0.0/0",
+                "target": "ENI-FW-az2-p2"
+              },
+              {
+                "destination": "s3",
+                "target": "s3"
+              }
+            ]
+          },
+          {
+            "name": "Proxy_azA",
+            "routes": [
+              {
+                "destination": "0.0.0.0/0",
+                "target": "ENI-FW-az1-p4"
+              }
+            ]
+          },
+          {
+            "name": "Proxy_azB",
+            "routes": [
+              {
+                "destination": "0.0.0.0/0",
+                "target": "ENI-FW-az2-p4"
+              }
+            ]
+          }
+        ],
+        "tgw-attach": {
+          "associate-to-tgw": false
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "deployments":{
-        "firewall":{
-          "instance-sizes":"c5n.2xl",
-          "eni":{
-            "count":4,
-            "p1-subnet":"Public",
-            "p2-subnet":"OnPremise",
-            "p3-subnet":"FWMgmt",
-            "p4-subnet":"Proxy"
+      "deployments": {
+        "firewall": {
+          "instance-sizes": "c5n.2xl",
+          "eni": {
+            "count": 4,
+            "p1-subnet": "Public",
+            "p2-subnet": "OnPremise",
+            "p3-subnet": "FWMgmt",
+            "p4-subnet": "Proxy"
           },
-          "auto-scale":{
-            "min-qty":2,
-            "max-qty":2
+          "auto-scale": {
+            "min-qty": 2,
+            "max-qty": 2
           },
-          "script":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/firewall.yaml",
-          "tgw-attach":{
-            "associate-to-tgw":"Main",
-            "account":"shared-network",
-            "associate-type":"VPN",
-            "rt-associate":[
-              "core"
-            ],
-            "rt-propogate":[
-              "core",
-              "segregated",
-              "shared",
-              "standalone"
-            ],
-            "blackhole-route":false,
-            "attach-subnets":[
-
-            ],
-            "options":[
-              "DNS-support",
-              "IPv6-support"
-            ]
+          "script": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/firewall.yaml",
+          "tgw-attach": {
+            "associate-to-tgw": "Main",
+            "account": "shared-network",
+            "associate-type": "VPN",
+            "rt-associate": ["core"],
+            "rt-propogate": ["core", "segregated", "shared", "standalone"],
+            "blackhole-route": false,
+            "attach-subnets": [],
+            "options": ["DNS-support", "IPv6-support"]
           }
         }
       }
     },
-    "master":{
-      "account-name":"primary",
-      "email":"bmycroft+lzT@amazon.com",
-      "ou":"core",
-      "landing-zone-account-type":"primary",
-      "share-mad-from":"operations",
-      "limits":{
-        "AWS Organizations/Maximum accounts":20,
-        "AWS CloudFormation/Stack count":400
+    "master": {
+      "account-name": "primary",
+      "email": "bmycroft+lzT@amazon.com",
+      "ou": "core",
+      "landing-zone-account-type": "primary",
+      "share-mad-from": "operations",
+      "limits": {
+        "AWS Organizations/Maximum accounts": 20,
+        "AWS CloudFormation/Stack count": 400
       },
-      "iam":{
-        "users":[
+      "iam": {
+        "users": [
           {
-            "user-ids":[
-              "bgUser1",
-              "bgUser2"
-            ],
-            "group":"BreakGlassAdmins",
-            "Policies":[
-              "Administrators"
-            ],
-            "BoundaryPolicy":"Default-Boundary-Policy"
+            "user-ids": ["bgUser1", "bgUser2"],
+            "group": "BreakGlassAdmins",
+            "Policies": ["Administrators"],
+            "BoundaryPolicy": "Default-Boundary-Policy"
           },
           {
-            "user-ids":[
-              "OpsUser1",
-              "OpsUser2"
-            ],
-            "group":"OpsAdmins",
-            "Policies":[
-              "Administrators"
-            ],
-            "BoundaryPolicy":"Default-Boundary-Policy"
+            "user-ids": ["OpsUser1", "OpsUser2"],
+            "group": "OpsAdmins",
+            "Policies": ["Administrators"],
+            "BoundaryPolicy": "Default-Boundary-Policy"
           }
         ],
-        "policies":[
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
-
-        ]
+        "roles": []
       },
-      "vpc":{
-        "deploy":"local",
-        "name":"ForSSO",
-        "cidr":"10.249.1.0/24",
-        "region":"ca-central-1",
-        "use-central-endpoints":false,
-        "flow-logs":false,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+      "vpc": {
+        "deploy": "local",
+        "name": "ForSSO",
+        "cidr": "10.249.1.0/24",
+        "region": "ca-central-1",
+        "use-central-endpoints": false,
+        "flow-logs": false,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"ForSSO",
-            "definitions":[
+            "name": "ForSSO",
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ForSSO_Shared",
-                "cidr":"10.249.1.0/27"
+                "az": "a",
+                "route-table": "ForSSO_Shared",
+                "cidr": "10.249.1.0/27"
               },
               {
-                "az":"b",
-                "route-table":"ForSSO_Shared",
-                "cidr":"10.249.1.32/27"
+                "az": "b",
+                "route-table": "ForSSO_Shared",
+                "cidr": "10.249.1.32/27"
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-
-        ],
-        "route-tables":[
+        "gateway-endpoints": [],
+        "route-tables": [
           {
-            "name":"ForSSO_Shared",
-            "routes":[
+            "name": "ForSSO_Shared",
+            "routes": [
               {
-                "destination":{
-                  "shared-Network-Central-GCWide-CIDR":null
+                "destination": {
+                  "shared-Network-Central-GCWide-CIDR": null
                 },
-                "target":"pcx-shared-network-Central"
+                "target": "pcx-shared-network-Central"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":false
+        "tgw-attach": {
+          "associate-to-tgw": false
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "deployments":{
-        "adc":{
-          "deploy":true,
-          "vpc-name":"ForSSO",
-          "subnet":"ForSSO",
-          "size":"small",
-          "restrict_srcips":[
-            "10.249.1.0/24",
-            "100.96.252.0/23"
-          ],
-          "connect-account-key":"operations",
-          "connect-dir-id":1001
+      "deployments": {
+        "adc": {
+          "deploy": true,
+          "vpc-name": "ForSSO",
+          "subnet": "ForSSO",
+          "size": "small",
+          "restrict_srcips": ["10.249.1.0/24", "100.96.252.0/23"],
+          "connect-account-key": "operations",
+          "connect-dir-id": 1001
         },
-        "sso":{
-          "deploy":true
+        "sso": {
+          "deploy": true
         }
       }
     },
-    "log-archive":{
-      "account-name":"log-archive",
-      "share-mad-from":"",
-      "ou":"core",
-      "email":"bmycroft+lzT+logs@amazon.com",
-      "landing-zone-account-type":"log-archive"
+    "log-archive": {
+      "account-name": "log-archive",
+      "share-mad-from": "",
+      "ou": "core",
+      "email": "bmycroft+lzT+logs@amazon.com",
+      "landing-zone-account-type": "log-archive"
     },
-    "security":{
-      "account-name":"security",
-      "share-mad-from":"",
-      "ou":"core",
-      "email":"bmycroft+lzT+security@amazon.com",
-      "landing-zone-account-type":"security"
+    "security": {
+      "account-name": "security",
+      "share-mad-from": "",
+      "ou": "core",
+      "email": "bmycroft+lzT+security@amazon.com",
+      "landing-zone-account-type": "security"
     },
-    "shared-services":{
-      "account-name":"shared-services",
-      "share-mad-from":"",
-      "ou":"core",
-      "email":"bmycroft+lzT+services@amazon.com",
-      "landing-zone-account-type":"shared-services",
-      "enable-s3-public-access":true
+    "shared-services": {
+      "account-name": "shared-services",
+      "share-mad-from": "",
+      "ou": "core",
+      "email": "bmycroft+lzT+services@amazon.com",
+      "landing-zone-account-type": "shared-services",
+      "enable-s3-public-access": true
     }
   },
-  "workload-account-configs":{
-    "fun-acct":{
-      "account-name":"TheFunAccount",
-      "email":"bmycroft+FunAcct@amazon.com",
-      "ou":"sandbox",
-      "share-mad-from":""
+  "workload-account-configs": {
+    "fun-acct": {
+      "account-name": "TheFunAccount",
+      "email": "bmycroft+FunAcct@amazon.com",
+      "ou": "sandbox",
+      "share-mad-from": ""
     }
   },
-  "organizational-units":{
-    "core":{
-      "type":"ignore",
-      "share-mad-from":"",
-      "SCPs":[
-        "ALZ-Core"
-      ]
+  "organizational-units": {
+    "core": {
+      "type": "ignore",
+      "share-mad-from": "",
+      "SCPs": ["ALZ-Core"]
     },
-    "central":{
-      "type":"mandatory",
-      "share-mad-from":"operations",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-PBMM-Only"
-      ],
-      "vpc":{
-        "deploy":"shared-network",
-        "name":"Central",
-        "cidr":"10.1.0.0/16",
-        "cidr2":"100.96.252.0/23",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":{
-          "source":"master",
-          "source-vpc":"ForSSO",
-          "source-subnets":"ForSSO",
-          "local-subnets":"GCWide"
+    "central": {
+      "type": "mandatory",
+      "share-mad-from": "operations",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-PBMM-Only"],
+      "vpc": {
+        "deploy": "shared-network",
+        "name": "Central",
+        "cidr": "10.1.0.0/16",
+        "cidr2": "100.96.252.0/23",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": {
+          "source": "master",
+          "source-vpc": "ForSSO",
+          "source-subnets": "ForSSO",
+          "local-subnets": "GCWide"
         },
-        "natgw":false,
-        "subnets":[
+        "natgw": false,
+        "subnets": [
           {
-            "name":"TGW",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "TGW",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.88.0/27"
+                "az": "a",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.88.0/27"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.88.32/27"
+                "az": "b",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.88.32/27"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.88.64/27",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.88.64/27",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Web",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-              "operations"
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": ["operations"],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.32.0/20"
+                "az": "a",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.128.0/20"
+                "az": "b",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-              "operations"
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": ["operations"],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.0.0/19"
+                "az": "a",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.96.0/19"
+                "az": "b",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.48.0/20"
+                "az": "a",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.144.0/20"
+                "az": "b",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.208.0/20",
+                "disabled": true
               }
             ],
-            "nacls":[
+            "nacls": [
               {
-                "rule":100,
-                "protocol":"-1",
-                "ports":"-1",
-                "rule-action":"deny",
-                "egress":true,
-                "cidr-blocks":[
+                "rule": 100,
+                "protocol": "-1",
+                "ports": "-1",
+                "rule-action": "deny",
+                "egress": true,
+                "cidr-blocks": [
                   {
-                    "subnet":"Web"
+                    "subnet": "Web"
                   },
                   {
-                    "vpc":"central",
-                    "subnet":[
-                      "Data"
-                    ]
+                    "vpc": "central",
+                    "subnet": ["Data"]
                   }
                 ]
               },
               {
-                "rule":32000,
-                "protocol":"-1",
-                "ports":"-1",
-                "rule-action":"allow",
-                "egress":true,
-                "cidr-blocks":[
-                  "0.0.0.0/0"
-                ]
+                "rule": 32000,
+                "protocol": "-1",
+                "ports": "-1",
+                "rule-action": "allow",
+                "egress": true,
+                "cidr-blocks": ["0.0.0.0/0"]
               },
               {
-                "rule":100,
-                "protocol":"-1",
-                "ports":"-1",
-                "rule-action":"deny",
-                "egress":false,
-                "cidr-blocks":[
+                "rule": 100,
+                "protocol": "-1",
+                "ports": "-1",
+                "rule-action": "deny",
+                "egress": false,
+                "cidr-blocks": [
                   {
-                    "subnet":"Web"
+                    "subnet": "Web"
                   },
                   {
-                    "vpc":"central",
-                    "subnet":[
-                      "Data"
-                    ]
+                    "vpc": "central",
+                    "subnet": ["Data"]
                   }
                 ]
               },
               {
-                "rule":32000,
-                "protocol":-1,
-                "ports":"-1",
-                "rule-action":"allow",
-                "egress":false,
-                "cidr-blocks":[
-                  "0.0.0.0/0"
-                ]
+                "rule": 32000,
+                "protocol": -1,
+                "ports": "-1",
+                "rule-action": "allow",
+                "egress": false,
+                "cidr-blocks": ["0.0.0.0/0"]
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-              "operations"
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": ["operations"],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.64.0/21"
+                "az": "a",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.72.0/21"
+                "az": "b",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_Common",
-                "cidr":"10.1.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_Common",
+                "cidr": "10.1.80.0/21",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"GCWide",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-              "operations"
-            ],
-            "definitions":[
+            "name": "GCWide",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": ["operations"],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"CentralVPC_GCWide",
-                "cidr2":"100.96.252.0/25"
+                "az": "a",
+                "route-table": "CentralVPC_GCWide",
+                "cidr2": "100.96.252.0/25"
               },
               {
-                "az":"b",
-                "route-table":"CentralVPC_GCWide",
-                "cidr2":"100.96.252.128/25"
+                "az": "b",
+                "route-table": "CentralVPC_GCWide",
+                "cidr2": "100.96.252.128/25"
               },
               {
-                "az":"d",
-                "route-table":"CentralVPC_GCWide",
-                "cidr2":"100.96.253.0/25",
-                "disabled":true
+                "az": "d",
+                "route-table": "CentralVPC_GCWide",
+                "cidr2": "100.96.253.0/25",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-          "s3",
-          "dynamodb"
-        ],
-        "route-tables":[
+        "gateway-endpoints": ["s3", "dynamodb"],
+        "route-tables": [
           {
-            "name":"CentralVPC_Common",
-            "routes":[
+            "name": "CentralVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               }
             ]
           },
           {
-            "name":"CentralVPC_GCWide",
-            "routes":[
+            "name": "CentralVPC_GCWide",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               },
               {
-                "destination":{
-                  "master-ForSSO-ForSSO-CIDR":null
+                "destination": {
+                  "master-ForSSO-ForSSO-CIDR": null
                 },
-                "target":"pcx-master-ForSSO"
+                "target": "pcx-master-ForSSO"
               }
             ]
           }
         ],
-        "security-groups":[
+        "security-groups": [
           {
-            "name":"Mgmt",
-            "inbound-rules":[
+            "name": "Mgmt",
+            "inbound-rules": [
               {
-                "description":"Allow Mgmt Traffic Inbound",
-                "type":[
-                  "RDP",
-                  "SSH"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "Allow Mgmt Traffic Inbound",
+                "type": ["RDP", "SSH"],
+                "source": ["0.0.0.0/0"]
               },
               {
-                "description":"Central VPC Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Central VPC Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "vpc":"Central",
-                    "subnet":[
-                      "Web",
-                      "App",
-                      "Mgmt",
-                      "GCWide"
-                    ]
+                    "vpc": "Central",
+                    "subnet": ["Web", "App", "Mgmt", "GCWide"]
                   }
                 ]
               }
             ],
-            "outbound-rules":[
+            "outbound-rules": [
               {
-                "description":"All Outbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "All Outbound",
+                "type": ["ALL"],
+                "source": ["0.0.0.0/0"]
               }
             ]
           },
           {
-            "name":"Web",
-            "inbound-rules":[
+            "name": "Web",
+            "inbound-rules": [
               {
-                "description":"Web Traffic Inbound",
-                "type":[
-                  "HTTP",
-                  "HTTPS"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "Web Traffic Inbound",
+                "type": ["HTTP", "HTTPS"],
+                "source": ["0.0.0.0/0"]
               },
               {
-                "description":"Central VPC Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Central VPC Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "vpc":"Central",
-                    "subnet":[
-                      "Web",
-                      "App",
-                      "Mgmt",
-                      "GCWide"
-                    ]
+                    "vpc": "Central",
+                    "subnet": ["Web", "App", "Mgmt", "GCWide"]
                   }
                 ]
               },
               {
-                "description":"Mgmt Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Mgmt Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "vpc":"Central",
-                    "security-group":[
-                      "Mgmt"
-                    ]
+                    "vpc": "Central",
+                    "security-group": ["Mgmt"]
                   }
                 ]
               }
             ],
-            "outbound-rules":[
+            "outbound-rules": [
               {
-                "description":"All Outbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "All Outbound",
+                "type": ["ALL"],
+                "source": ["0.0.0.0/0"]
               }
             ]
           },
           {
-            "name":"App",
-            "inbound-rules":[
+            "name": "App",
+            "inbound-rules": [
               {
-                "description":"Central VPC Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Central VPC Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "vpc":"Central",
-                    "subnet":[
-                      "Web",
-                      "App",
-                      "Mgmt",
-                      "GCWide"
-                    ]
+                    "vpc": "Central",
+                    "subnet": ["Web", "App", "Mgmt", "GCWide"]
                   }
                 ]
               },
               {
-                "description":"Mgmt Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Mgmt Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "security-group":[
-                      "Mgmt"
-                    ]
+                    "security-group": ["Mgmt"]
                   }
                 ]
               },
               {
-                "description":"Web Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Web Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "security-group":[
-                      "Web"
-                    ]
+                    "security-group": ["Web"]
                   }
                 ]
               },
               {
-                "description":"Allow East/West Communication Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Allow East/West Communication Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "security-group":[
-                      "App"
-                    ]
+                    "security-group": ["App"]
                   }
                 ]
               }
             ],
-            "outbound-rules":[
+            "outbound-rules": [
               {
-                "description":"All Outbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "All Outbound",
+                "type": ["ALL"],
+                "source": ["0.0.0.0/0"]
               }
             ]
           },
           {
-            "name":"Data",
-            "inbound-rules":[
+            "name": "Data",
+            "inbound-rules": [
               {
-                "description":"Central VPC Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Central VPC Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "vpc":"Central",
-                    "subnet":[
-                      "Web",
-                      "App",
-                      "Mgmt",
-                      "GCWide"
-                    ]
+                    "vpc": "Central",
+                    "subnet": ["Web", "App", "Mgmt", "GCWide"]
                   }
                 ]
               },
               {
-                "description":"Mgmt Traffic Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Mgmt Traffic Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "security-group":[
-                      "Mgmt"
-                    ]
+                    "security-group": ["Mgmt"]
                   }
                 ]
               },
               {
-                "description":"App Traffic Inbound",
-                "type":[
-                  "MSSQL",
-                  "MYSQL/AURORA",
-                  "REDSHIFT",
-                  "POSTGRESQL",
-                  "ORACLE-RDS"
-                ],
-                "source":[
+                "description": "App Traffic Inbound",
+                "type": ["MSSQL", "MYSQL/AURORA", "REDSHIFT", "POSTGRESQL", "ORACLE-RDS"],
+                "source": [
                   {
-                    "security-group":[
-                      "App"
-                    ]
+                    "security-group": ["App"]
                   }
                 ]
               },
               {
-                "description":"Allow East/West Communication Inbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
+                "description": "Allow East/West Communication Inbound",
+                "type": ["ALL"],
+                "source": [
                   {
-                    "security-group":[
-                      "Data"
-                    ]
+                    "security-group": ["Data"]
                   }
                 ]
               }
             ],
-            "outbound-rules":[
+            "outbound-rules": [
               {
-                "description":"All Outbound",
-                "type":[
-                  "ALL"
-                ],
-                "source":[
-                  "0.0.0.0/0"
-                ]
+                "description": "All Outbound",
+                "type": ["ALL"],
+                "source": ["0.0.0.0/0"]
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"shared-network",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "shared"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "shared",
-            "segregated"
-          ],
-          "blackhole-route":false,
-          "attach-subnets":[
-            "TGW"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "shared-network",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["shared"],
+          "tgw-rt-propagate": ["core", "shared", "segregated"],
+          "blackhole-route": false,
+          "attach-subnets": ["TGW"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }
     },
-    "dev":{
-      "type":"workload",
-      "share-mad-from":"operations",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-PBMM-Only"
-      ],
-      "vpc":{
-        "deploy":"shared-network",
-        "name":"Dev",
-        "cidr":"10.2.0.0/16",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+    "dev": {
+      "type": "workload",
+      "share-mad-from": "operations",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-PBMM-Only"],
+      "vpc": {
+        "deploy": "shared-network",
+        "name": "Dev",
+        "cidr": "10.2.0.0/16",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"TGW",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "TGW",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.88.0/27"
+                "az": "a",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.88.0/27"
               },
               {
-                "az":"b",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.88.32/27"
+                "az": "b",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.88.32/27"
               },
               {
-                "az":"d",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.88.64/27",
-                "disabled":true
+                "az": "d",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.88.64/27",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Web",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.32.0/20"
+                "az": "a",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.128.0/20"
+                "az": "b",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.0.0/19"
+                "az": "a",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.96.0/19"
+                "az": "b",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.48.0/20"
+                "az": "a",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.144.0/20"
+                "az": "b",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.208.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.64.0/21"
+                "az": "a",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.72.0/21"
+                "az": "b",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"DevVPC_Common",
-                "cidr":"10.2.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "DevVPC_Common",
+                "cidr": "10.2.80.0/21",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-          "s3",
-          "dynamodb"
-        ],
-        "route-tables":[
+        "gateway-endpoints": ["s3", "dynamodb"],
+        "route-tables": [
           {
-            "name":"DevVPC_Common",
-            "routes":[
+            "name": "DevVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"shared-network",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "segregated"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "shared"
-          ],
-          "blackhole-route":true,
-          "attach-subnets":[
-            "TGW"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "shared-network",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["segregated"],
+          "tgw-rt-propagate": ["core", "shared"],
+          "blackhole-route": true,
+          "attach-subnets": ["TGW"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }
     },
-    "test":{
-      "type":"workload",
-      "share-mad-from":"operations",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-PBMM-Only"
-      ],
-      "vpc":{
-        "deploy":"shared-network",
-        "name":"Test",
-        "cidr":"10.3.0.0/16",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+    "test": {
+      "type": "workload",
+      "share-mad-from": "operations",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-PBMM-Only"],
+      "vpc": {
+        "deploy": "shared-network",
+        "name": "Test",
+        "cidr": "10.3.0.0/16",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"TGW",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "TGW",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.88.0/27"
+                "az": "a",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.88.0/27"
               },
               {
-                "az":"b",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.88.32/27"
+                "az": "b",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.88.32/27"
               },
               {
-                "az":"d",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.88.64/27",
-                "disabled":true
+                "az": "d",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.88.64/27",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Web",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.32.0/20"
+                "az": "a",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.128.0/20"
+                "az": "b",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.0.0/19"
+                "az": "a",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.96.0/19"
+                "az": "b",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.48.0/20"
+                "az": "a",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.144.0/20"
+                "az": "b",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.208.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.64.0/21"
+                "az": "a",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.72.0/21"
+                "az": "b",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"TestVPC_Common",
-                "cidr":"10.3.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "TestVPC_Common",
+                "cidr": "10.3.80.0/21",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-          "s3",
-          "dynamodb"
-        ],
-        "route-tables":[
+        "gateway-endpoints": ["s3", "dynamodb"],
+        "route-tables": [
           {
-            "name":"TestVPC_Common",
-            "routes":[
+            "name": "TestVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"shared-network",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "segregated"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "shared"
-          ],
-          "blackhole-route":true,
-          "attach-subnets":[
-            "TGW"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "shared-network",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["segregated"],
+          "tgw-rt-propagate": ["core", "shared"],
+          "blackhole-route": true,
+          "attach-subnets": ["TGW"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }
     },
-    "prod":{
-      "type":"workload",
-      "share-mad-from":"operations",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-PBMM-Only"
-      ],
-      "vpc":{
-        "deploy":"shared-network",
-        "name":"Prod",
-        "cidr":"10.4.0.0/16",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+    "prod": {
+      "type": "workload",
+      "share-mad-from": "operations",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-PBMM-Only"],
+      "vpc": {
+        "deploy": "shared-network",
+        "name": "Prod",
+        "cidr": "10.4.0.0/16",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"TGW",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "TGW",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.88.0/27"
+                "az": "a",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.88.0/27"
               },
               {
-                "az":"b",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.88.32/27"
+                "az": "b",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.88.32/27"
               },
               {
-                "az":"d",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.88.64/27",
-                "disabled":true
+                "az": "d",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.88.64/27",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Web",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.32.0/20"
+                "az": "a",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.128.0/20"
+                "az": "b",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.0.0/19"
+                "az": "a",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.96.0/19"
+                "az": "b",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.48.0/20"
+                "az": "a",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.144.0/20"
+                "az": "b",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.208.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.64.0/21"
+                "az": "a",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.72.0/21"
+                "az": "b",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"ProdVPC_Common",
-                "cidr":"10.4.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "ProdVPC_Common",
+                "cidr": "10.4.80.0/21",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-          "s3",
-          "dynamodb"
-        ],
-        "route-tables":[
+        "gateway-endpoints": ["s3", "dynamodb"],
+        "route-tables": [
           {
-            "name":"ProdVPC_Common",
-            "routes":[
+            "name": "ProdVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"shared-network",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "segregated"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "shared"
-          ],
-          "blackhole-route":true,
-          "attach-subnets":[
-            "TGW"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "shared-network",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["segregated"],
+          "tgw-rt-propagate": ["core", "shared"],
+          "blackhole-route": true,
+          "attach-subnets": ["TGW"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }
     },
-    "unclass":{
-      "type":"workload",
-      "share-mad-from":"operations",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-Unclass-Only"
-      ],
-      "vpc":{
-        "deploy":"shared-network",
-        "name":"UnClass",
-        "cidr":"10.5.0.0/16",
-        "region":"ca-central-1",
-        "use-central-endpoints":true,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":false,
-        "vgw":false,
-        "pcx":false,
-        "natgw":false,
-        "subnets":[
+    "unclass": {
+      "type": "workload",
+      "share-mad-from": "operations",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-Unclass-Only"],
+      "vpc": {
+        "deploy": "shared-network",
+        "name": "UnClass",
+        "cidr": "10.5.0.0/16",
+        "region": "ca-central-1",
+        "use-central-endpoints": true,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": false,
+        "vgw": false,
+        "pcx": false,
+        "natgw": false,
+        "subnets": [
           {
-            "name":"TGW",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "TGW",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.88.0/27"
+                "az": "a",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.88.0/27"
               },
               {
-                "az":"b",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.88.32/27"
+                "az": "b",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.88.32/27"
               },
               {
-                "az":"d",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.88.64/27",
-                "disabled":true
+                "az": "d",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.88.64/27",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Web",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.32.0/20"
+                "az": "a",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.128.0/20"
+                "az": "b",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.0.0/19"
+                "az": "a",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.96.0/19"
+                "az": "b",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":true,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": true,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.48.0/20"
+                "az": "a",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.144.0/20"
+                "az": "b",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.208.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.64.0/21"
+                "az": "a",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.72.0/21"
+                "az": "b",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"UnClassVPC_Common",
-                "cidr":"10.5.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "UnClassVPC_Common",
+                "cidr": "10.5.80.0/21",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-          "s3",
-          "dynamodb"
-        ],
-        "route-tables":[
+        "gateway-endpoints": ["s3", "dynamodb"],
+        "route-tables": [
           {
-            "name":"UnClassVPC_Common",
-            "routes":[
+            "name": "UnClassVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"TGW"
+                "destination": "0.0.0.0/0",
+                "target": "TGW"
               },
               {
-                "destination":"s3",
-                "target":"s3"
+                "destination": "s3",
+                "target": "s3"
               },
               {
-                "destination":"DynamoDB",
-                "target":"DynamoDB"
+                "destination": "DynamoDB",
+                "target": "DynamoDB"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":"Main",
-          "account":"shared-network",
-          "associate-type":"ATTACH",
-          "tgw-rt-associate":[
-            "segregated"
-          ],
-          "tgw-rt-propagate":[
-            "core",
-            "shared"
-          ],
-          "blackhole-route":true,
-          "attach-subnets":[
-            "TGW"
-          ],
-          "options":[
-            "DNS-support",
-            "IPv6-support"
-          ]
+        "tgw-attach": {
+          "associate-to-tgw": "Main",
+          "account": "shared-network",
+          "associate-type": "ATTACH",
+          "tgw-rt-associate": ["segregated"],
+          "tgw-rt-propagate": ["core", "shared"],
+          "blackhole-route": true,
+          "attach-subnets": ["TGW"],
+          "options": ["DNS-support", "IPv6-support"]
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }
     },
-    "sandbox":{
-      "type":"workload",
-      "share-mad-from":"",
-      "SCPs":[
-        "ALZ-Non-Core",
-        "Guardrails-Part1",
-        "Guardrails-Part2",
-        "Guardrails-Unclass-Only"
-      ],
-      "vpc":{
-        "deploy":"local",
-        "name":"Sandbox",
-        "cidr":"10.6.0.0/16",
-        "region":"ca-central-1",
-        "use-central-endpoints":false,
-        "flow-logs":true,
-        "log-retention":90,
-        "igw":true,
-        "vgw":false,
-        "pcx":false,
-        "natgw":{
-          "subnet":{
-            "name":"Web",
-            "az":"a"
+    "sandbox": {
+      "type": "workload",
+      "share-mad-from": "",
+      "SCPs": ["ALZ-Non-Core", "Guardrails-Part1", "Guardrails-Part2", "Guardrails-Unclass-Only"],
+      "vpc": {
+        "deploy": "local",
+        "name": "Sandbox",
+        "cidr": "10.6.0.0/16",
+        "region": "ca-central-1",
+        "use-central-endpoints": false,
+        "flow-logs": true,
+        "log-retention": 90,
+        "igw": true,
+        "vgw": false,
+        "pcx": false,
+        "natgw": {
+          "subnet": {
+            "name": "Web",
+            "az": "a"
           }
         },
-        "subnets":[
+        "subnets": [
           {
-            "name":"Web",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Web",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"SandboxVPC_IGW",
-                "cidr":"10.6.32.0/20"
+                "az": "a",
+                "route-table": "SandboxVPC_IGW",
+                "cidr": "10.6.32.0/20"
               },
               {
-                "az":"b",
-                "route-table":"SandboxVPC_IGW",
-                "cidr":"10.6.128.0/20"
+                "az": "b",
+                "route-table": "SandboxVPC_IGW",
+                "cidr": "10.6.128.0/20"
               },
               {
-                "az":"d",
-                "route-table":"SandboxVPC_IGW",
-                "cidr":"10.6.192.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "SandboxVPC_IGW",
+                "cidr": "10.6.192.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"App",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "App",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.0.0/19"
+                "az": "a",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.0.0/19"
               },
               {
-                "az":"b",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.96.0/19"
+                "az": "b",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.96.0/19"
               },
               {
-                "az":"d",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.160.0/19",
-                "disabled":true
+                "az": "d",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.160.0/19",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Data",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Data",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.48.0/20"
+                "az": "a",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.48.0/20"
               },
               {
-                "az":"b",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.144.0/20"
+                "az": "b",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.144.0/20"
               },
               {
-                "az":"d",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.208.0/20",
-                "disabled":true
+                "az": "d",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.208.0/20",
+                "disabled": true
               }
             ]
           },
           {
-            "name":"Mgmt",
-            "share-to-ou-accounts":false,
-            "share-to-specific-accounts":[
-
-            ],
-            "definitions":[
+            "name": "Mgmt",
+            "share-to-ou-accounts": false,
+            "share-to-specific-accounts": [],
+            "definitions": [
               {
-                "az":"a",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.64.0/21"
+                "az": "a",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.64.0/21"
               },
               {
-                "az":"b",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.72.0/21"
+                "az": "b",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.72.0/21"
               },
               {
-                "az":"d",
-                "route-table":"SandboxVPC_Common",
-                "cidr":"10.6.80.0/21",
-                "disabled":true
+                "az": "d",
+                "route-table": "SandboxVPC_Common",
+                "cidr": "10.6.80.0/21",
+                "disabled": true
               }
             ]
           }
         ],
-        "gateway-endpoints":[
-
-        ],
-        "route-tables":[
+        "gateway-endpoints": [],
+        "route-tables": [
           {
-            "name":"SandboxVPC_IGW",
-            "routes":[
+            "name": "SandboxVPC_IGW",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"IGW"
+                "destination": "0.0.0.0/0",
+                "target": "IGW"
               }
             ]
           },
           {
-            "name":"SandboxVPC_Common",
-            "routes":[
+            "name": "SandboxVPC_Common",
+            "routes": [
               {
-                "destination":"0.0.0.0/0",
-                "target":"NATGW_Web_azA"
+                "destination": "0.0.0.0/0",
+                "target": "NATGW_Web_azA"
               }
             ]
           }
         ],
-        "tgw-attach":{
-          "associate-to-tgw":false
+        "tgw-attach": {
+          "associate-to-tgw": false
         },
-        "interface-endpoints":false
+        "interface-endpoints": false
       },
-      "iam":{
-        "users":[
-
-        ],
-        "policies":[
+      "iam": {
+        "users": [],
+        "policies": [
           {
-            "Policy-Name":"Default-Boundary-Policy",
-            "Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
+            "Policy-Name": "Default-Boundary-Policy",
+            "Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/boundary-policy.txt"
           }
         ],
-        "roles":[
+        "roles": [
           {
-            "Role":"EC2-Default-SSM-AD",
-            "Type":"EC2",
-            "Policies":[
+            "Role": "EC2-Default-SSM-AD",
+            "Type": "EC2",
+            "Policies": [
               "AmazonSSMManagedInstanceCore",
               "AmazonSSMDirectoryServiceAccess",
               "CloudWatchAgentServerPolicy"
             ],
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ],
-            "SourceAccount":"",
-            "SourceAccount-role":""
+            "BoundaryPolicy": ["Default-Boundary-Policy"],
+            "SourceAccount": "",
+            "SourceAccount-role": ""
           },
           {
-            "Role":"Test-Role",
-            "Type":"Account",
-            "Policies":[
-              "AdministratorAccess"
-            ],
-            "SourceAccount":"security",
-            "SourceRole":"AWSLandingZoneSecurityAdministratorRole",
-            "Trust-Policy":"https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
-            "BoundaryPolicy":[
-              "Default-Boundary-Policy"
-            ]
+            "Role": "Test-Role",
+            "Type": "Account",
+            "Policies": ["AdministratorAccess"],
+            "SourceAccount": "security",
+            "SourceRole": "AWSLandingZoneSecurityAdministratorRole",
+            "Trust-Policy": "https://canada-accelerator.s3.ca-central-1.amazonaws.com/v0.1/role-trust-policy.txt",
+            "BoundaryPolicy": ["Default-Boundary-Policy"]
           }
         ]
       }


### PR DESCRIPTION
- Tweaked object naming for consistency purposes az1 to azA, endpoint rt names
- Added more operations subnets for sharing

***While most of the above are minor and have zero functional impact, the change to the NATGW route designations for NATGW_Web_az1 to NATGW_Web_azB COULD break something

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
