### PR TITLE
Exclude aurora from rds:CreateDBInstance SCP

### DIFF
--- a/reference-artifacts/SCPs/PBMMAccel-Guardrails-Part2.json
+++ b/reference-artifacts/SCPs/PBMMAccel-Guardrails-Part2.json
@@ -63,6 +63,9 @@
       "Action":"rds:CreateDBInstance",
       "Resource":"arn:aws:rds:*:*:db:*",
       "Condition":{
+        "StringNotLike":{
+          "rds:DatabaseEngine":"aurora*"
+        },
         "Bool":{
           "rds:StorageEncrypted":"false"
         }
@@ -74,6 +77,9 @@
       "Action":"rds:CreateDBCluster",
       "Resource":"*",
       "Condition":{
+        "StringLike": {
+          "rds:DatabaseEngine":"aurora*"
+        },
         "Bool":{
           "rds:StorageEncrypted":"false"
         }


### PR DESCRIPTION
Encryption is handled at the cluster level with Aurora, not instance level.

*Issue #, if available:*

*Description of changes:* In Aurora, encryption is at the cluster level, not instance level. Without this exception, you cannot create an Aurora DB instance (i.e. reader/writer).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
