### PR TITLE
Adding access-analyzer and fixing casing on ListBuckets

### DIFF
--- a/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
+++ b/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
@@ -54,6 +54,7 @@
       "Effect":"Deny",
       "NotAction":[
         "a4b:*",
+        "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
         "aws-portal:*",
@@ -76,8 +77,8 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:ListBuckets",
         "s3:PutAccountPublic*",
-        "s3:listBuckets",
         "shield:*",
         "sts:*",
         "support:*",

--- a/reference-artifacts/SCPs/PBMMAccel-Guardrails-Unclass-Only.json
+++ b/reference-artifacts/SCPs/PBMMAccel-Guardrails-Unclass-Only.json
@@ -6,6 +6,7 @@
       "Effect":"Deny",
       "NotAction":[
         "a4b:*",
+        "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
         "aws-portal:*",
@@ -28,8 +29,8 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:ListBuckets",
         "s3:PutAccountPublic*",
-        "s3:listBuckets",
         "shield:*",
         "sts:*",
         "support:*",


### PR DESCRIPTION
*Description of changes:* Adding to the list of global services.

As a side note, the policy simulator has the most comprehensive list of permission namespaces that I've seen anywhere: https://policysim.aws.amazon.com/home/index.jsp. You do need to watch the POST in the network request to get the actual name, though.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
