### PR TITLE
Minor fix to the error message on config load fail

### DIFF
--- a/common-lambda/lib/config/load.ts
+++ b/common-lambda/lib/config/load.ts
@@ -16,6 +16,6 @@ export async function loadAcceleratorConfig(props: {
     const source = file.fileContent.toString();
     return AcceleratorConfig.fromString(source);
   } catch (e) {
-    throw new Error(`Cannot find file with name "${filePath}" in Repository ${repositoryName}\n${e.message}`);
+    throw new Error(`Unable to load configuration file "${filePath}" in Repository ${repositoryName}\n${e.message}`);
   }
 }


### PR DESCRIPTION
*Description of changes:* Very minor change to the wording on failure to load config file. I was misled by this - initially thought it couldn't see the file in CodeCommit, but was actually due to a missing config section.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
