### PR TITLE
Exempt KMS from DenyAllOutsideCanadaPBMMONLY SCP

### DIFF
--- a/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
+++ b/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
@@ -57,7 +57,7 @@
     {
       "Sid": "ScopeSpecificGlobalActionsToCanadaUSE1",
       "Effect": "Deny",
-      "Action": ["acm:*"],
+      "Action": ["acm:*", "kms:*"],
       "Resource": "*",
       "Condition": {
         "StringNotEquals": {
@@ -94,6 +94,7 @@
         "health:*",
         "iam:*",
         "importexport:*",
+        "kms:*",
         "mobileanalytics:*",
         "organizations:*",
         "pricing:*",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  Exempting KMS from the `DenyAllOutsideCanadaPBMMONLY` list for the same rationale as ACM. In order to create, and later use with CloudFront, an IAD-domiciled ACM certificate, a principal needs access to the `aws/acm` AWS-managed CMK. The omission of `kms:*` was causing this to fail in both the creation and usage case. 

Further scoping is not possible in the SCP because `NotResource` is not expressible in SCPs, nor are the condition keys provided by KMS adequate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
