### PR TITLE
chore: Use release prefix for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - 'bump/v*'
+      - 'release/v*'
 jobs:
   release:
     name: Release
@@ -21,7 +21,7 @@ jobs:
           git fetch --tags
           echo ::set-output name=branch_name::$(echo "${GITHUB_REF}" | cut -d/ -f3-)
           echo ::set-output name=tag_name::$(echo "${GITHUB_REF}" | cut -d/ -f4-)
-          echo ::set-output name=release_name::"Release $(echo "${GITHUB_REF}" | cut -d/ -f3- | sed 's/bump\///')"
+          echo ::set-output name=release_name::"Release $(echo "${GITHUB_REF}" | cut -d/ -f4-)"
       - name: Use Node.js
         uses: actions/setup-node@v1
         env:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If using an internal AWS account, to successfully install, you need to enable pr
 7. Add an `Email` address to be used for notification of code releases
 8. The `GithubBranch` should point to the release you selected
    - if upgrading, change it to point to the desired release
-   - the latest stable branch is currently `bump/v1.0.5`, case sensitive
+   - the latest stable branch is currently `release/v1.0.5`, case sensitive
 9. Apply a tag on the stack, Key=`Accelerator`, Value=`PBMM` (case sensitive).
 10. **ENABLE STACK TERMINATION PROTECTION** under `Stack creation options`
 11. The stack typically takes under 5 minutes to deploy.
@@ -137,9 +137,9 @@ If using an internal AWS account, to successfully install, you need to enable pr
 ## Release Process
 
 1. Ensure `master` is in a suitable state
-2. Create a version branch with [SemVer](https://semver.org/) semantics and a `bump/` prefix: e.g. `bump/v1.0.5`
+2. Create a version branch with [SemVer](https://semver.org/) semantics and a `release/` prefix: e.g. `release/v1.0.5`
 
-- **Important:** Certain git operations are ambiguous if tags and branches have the same name. Using the `bump/` prefix reserves the actual version name for the tag itself.
+- **Important:** Certain git operations are ambiguous if tags and branches have the same name. Using the `release/` prefix reserves the actual version name for the tag itself.
 
 3. Push that branch to GitHub (if created locally)
 4. The release workflow will run, and create a **draft** release if successful with all commits since the last tagged release.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Rename the release branch to have a `release/` prefix.

Once merged, I'll also protect `release/v*` branches and created a correspondingly named branch for v1.0.5-rc5


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
