### PR TITLE
fix(core): Embed aws-sdk in guardduty-enable-admin custom resource

### DIFF
--- a/custom-resources/guardduty-enable-admin/lambda/package.json
+++ b/custom-resources/guardduty-enable-admin/lambda/package.json
@@ -9,8 +9,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "externals": [
-    "aws-lambda",
-    "aws-sdk"
+    "aws-lambda"
   ],
   "devDependencies": {
     "@custom-resources/webpack-base": "workspace:^0.0.1",
@@ -24,6 +23,6 @@
   "dependencies": {
     "@custom-resources/cfn-response": "workspace:^0.0.1",
     "aws-lambda": "1.0.5",
-    "aws-sdk": "2.668.0"
+    "aws-sdk": "2.711.0"
   }
 }


### PR DESCRIPTION
The method `AWS.GuardDuty.enableOrganizationAdminAccount` was only introduced in `aws-sdk ` 2.660.0. NodeJS 12 runtime only has `aws-sdk` `2.631.0`.

See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html