### PR TITLE
feature(core): z129 added option to exclude alb deployment on a workload account

### DIFF
--- a/reference-artifacts/master-config-sample-snippets/sample_snippets.md
+++ b/reference-artifacts/master-config-sample-snippets/sample_snippets.md
@@ -4,6 +4,18 @@
 
 ---
 
+- Added an option to exclude the alb deployment on a specific workload account
+
+```
+  "workload-account-configs": {
+    "fun-acct": {
+      "exclude-ou-albs": true
+    }
+  }
+```
+
+---
+
 - Update Central Logging Kinesis stream shard count as accounts are added
 
 ```

--- a/src/deployments/cdk/src/deployments/alb/step-1.ts
+++ b/src/deployments/cdk/src/deployments/alb/step-1.ts
@@ -38,9 +38,17 @@ export async function step1(props: AlbStep1Props) {
   });
 
   const vpcConfigs = config.getVpcConfigs();
-  for (const { accountKey, albs: albConfigs } of config.getAlbConfigs()) {
+  for (const { ouKey, accountKey, albs: albConfigs } of config.getAlbConfigs()) {
     if (albConfigs.length === 0) {
       continue;
+    }
+
+    if (ouKey) {
+      const accountConfigs = config.getAccountConfigsForOu(ouKey);
+      const accountConfig = accountConfigs.find(([aKey, _]) => aKey === accountKey);
+      if (accountConfig && accountConfig[1]['exclude-ou-albs']) {
+        continue;
+      }
     }
 
     for (const albConfig of albConfigs) {

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -552,6 +552,7 @@ export const MandatoryAccountConfigType = t.interface({
   'cwl-retention': optional(t.number),
   deleted: fromNullable(t.boolean, false),
   'src-filename': t.string,
+  'exclude-ou-albs': optional(t.boolean),
 });
 
 export type MandatoryAccountConfig = t.TypeOf<typeof MandatoryAccountConfigType>;


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
