### PR TITLE
Fixing double zip issue with documentation build

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -200,5 +200,5 @@ jobs:
 
       - uses: actions/upload-artifact@master
         with:
-          name: ${{ steps.setup.outputs.dir }}.zip
+          name: ${{ steps.setup.outputs.dir }}
           path: ${{ steps.setup.outputs.dir }}/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Copy file output 2b1
         run: |
           cp reference-artifacts/config.lite-example.json ${{ steps.setup.outputs.dir }}/2b-${{ steps.setup.outputs.prefix }}-config.lite-example.json
-          
+
       - name: PDF output 2c
         uses: docker://pandoc/latex:2.10
         with:
@@ -198,10 +198,7 @@ jobs:
             --pdf-engine=xelatex
             docs/architectures/pbmm/architecture.md
 
-      - name: Zip
-        run: |
-          zip -r ${{ steps.setup.outputs.dir }}.zip ${{ steps.setup.outputs.dir }}/
       - uses: actions/upload-artifact@master
         with:
-          name: ${{ steps.setup.outputs.dir }}
-          path: ${{ steps.setup.outputs.dir }}.zip
+          name: ${{ steps.setup.outputs.dir }}.zip
+          path: ${{ steps.setup.outputs.dir }}/


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The GitHub Action `actions/upload-artifact` has a limitation (described [here](https://github.com/actions/upload-artifact#zipped-artifact-downloads) related to directory artifacts. Directories are dynamically zipped on download; thus there's no need to zip in the action itself.