### PR TITLE
Adding ec2:CreateDefaultVpc, ec2:CreateDefaultSubnet

### DIFF
--- a/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
+++ b/reference-artifacts/SCPs/PBMMAccel-Guardrails-PBMM-Only.json
@@ -8,6 +8,8 @@
         "ec2:AcceptVpcPeeringConnection",
         "ec2:AttachEgressOnlyInternetGateway",
         "ec2:AttachInternetGateway",
+        "ec2:CreateDefaultSubnet",
+        "ec2:CreateDefaultVpc",
         "ec2:CreateEgressOnlyInternetGateway",
         "ec2:CreateInternetGateway",
         "ec2:CreateNatGateway",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Turns out these are distinct permissions.