### PR TITLE
feat(core): Config Rules Remediation

### DIFF
--- a/reference-artifacts/config.example.json
+++ b/reference-artifacts/config.example.json
@@ -491,6 +491,11 @@
             "name": "SSM-ELB-Enable-Logging",
             "description": "Calls the AWS CLI to enable access logs on a specified ELB.",
             "template": "ssm-elb-enable-logging.yaml"
+          },
+          {
+            "name": "Put-S3-Encryption",
+            "description": "Enables S3 encryption using KMS",
+            "template": "s3-encryption.yaml"
           }
         ]
       }
@@ -514,6 +519,14 @@
             "remediation-params": {
               "LoadBalancerArn": "RESOURCE_ID",
               "LogDestination": "${SEA::LogArchiveAesBucket}"
+            }
+          },
+          {
+            "name": "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED",
+            "remediation-action": "Put-S3-Encryption",
+            "remediation-params": {
+              "BucketName": "RESOURCE_ID",
+              "KMSMasterKey": "${SEA::S3BucketEncryptionKey}"
             }
           }
         ]
@@ -1658,13 +1671,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]
@@ -2118,13 +2131,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]
@@ -2605,13 +2618,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]
@@ -3092,13 +3105,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]
@@ -3579,13 +3592,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]
@@ -4033,13 +4046,13 @@
         {
           "account": "operations",
           "regions": ["ca-central-1"],
-          "documents": ["SSM-ELB-Enable-Logging"]
+          "documents": ["SSM-ELB-Enable-Logging", "Put-S3-Encryption"]
         }
       ],
       "aws-config": [
         {
           "excl-regions": [],
-          "rules": ["ELB_LOGGING_ENABLED"],
+          "rules": ["ELB_LOGGING_ENABLED", "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"],
           "remediate-regions": ["ca-central-1"]
         }
       ]

--- a/reference-artifacts/ssm-documents/s3-encryption.yaml
+++ b/reference-artifacts/ssm-documents/s3-encryption.yaml
@@ -1,0 +1,28 @@
+description: Enables Encryption on S3 Bucket
+schemaVersion: "0.3"
+assumeRole: "{{ AutomationAssumeRole }}"
+parameters:
+  BucketName:
+    type: String
+    description: (Required) The name of the S3 Bucket whose content will be encrypted.
+  KMSMasterKey:
+    type: String
+    description: (Optional) AWS Key Management Service (KMS) customer master key ARN to use for the default encryption.
+  AutomationAssumeRole:
+    type: String
+    description: (Optional) The ARN of the role that allows Automation to perform the actions on your behalf.
+    default: ""
+mainSteps:
+- name: PutBucketEncryption
+  action: aws:executeAwsApi
+  inputs:
+    Service: s3
+    Api:  PutBucketEncryption
+    Bucket: "{{BucketName}}"
+    ServerSideEncryptionConfiguration:
+        Rules:
+        -
+          ApplyServerSideEncryptionByDefault:
+            SSEAlgorithm: "aws:kms"
+            KMSMasterKeyID: "{{KMSMasterKey}}"
+  isEnd: true

--- a/src/deployments/cdk/src/apps/phase-3.ts
+++ b/src/deployments/cdk/src/apps/phase-3.ts
@@ -130,11 +130,10 @@ export async function deploy({ acceleratorConfig, accountStacks, accounts, conte
 
   await awsConfig.createRule({
     acceleratorExecutionRoleName: context.acceleratorExecutionRoleName,
-    centralAccountId: '',
-    centralBucketName: centralBucket.bucketName,
     config: acceleratorConfig,
     accountStacks,
     accounts,
     outputs,
+    defaultRegion: context.defaultRegion,
   });
 }

--- a/src/deployments/cdk/src/deployments/config/create.ts
+++ b/src/deployments/cdk/src/deployments/config/create.ts
@@ -126,8 +126,10 @@ export async function createRule(props: CreateRuleProps) {
                     accounts,
                     ssmDocInOu.account,
                   )}:document/${remediationActionName}`;
+                } else if (config['global-options']['default-ssm-documents'].includes(remediationAction)) {
+                  targetId = remediationAction;
                 } else {
-                  console.warn(`No Remediation is Created in account "${accountKey}" and region "${region}"`);
+                  console.warn(`No Remediation "${remediationAction}"is Created in account "${accountKey}" and region "${region}"`);
                   continue;
                 }
               }
@@ -184,16 +186,13 @@ export function getRemediationParameters(params: {
 }): RemediationParameters {
   const reutrnParams: RemediationParameters = {};
   const { outputs, remediationParams, roleName, config } = params;
-  if (!remediationParams.AutomationAssumeRole) {
-    reutrnParams.AutomationAssumeRole = {
-      StaticValue: {
-        Values: [`arn:aws:iam::${cdk.Aws.ACCOUNT_ID}:role/${roleName}`],
-      },
-    };
-  }
+  reutrnParams.AutomationAssumeRole = {
+    StaticValue: {
+      Values: [`arn:aws:iam::${cdk.Aws.ACCOUNT_ID}:role/${ remediationParams.AutomationAssumeRole || roleName}`],
+    },
+  };
 
   Object.keys(remediationParams).map(key => {
-    console.log(remediationParams[key], remediationParams[key].startsWith('${SEA::'));
     if (remediationParams[key] === 'RESOURCE_ID') {
       reutrnParams[key] = {
         ResourceValue: {
@@ -216,7 +215,7 @@ export function getRemediationParameters(params: {
             },
           };
         } else {
-          reutrnParams.AutomationAssumeRole = {
+          reutrnParams[key] = {
             StaticValue: {
               Values: [remediationParams[key]],
             },

--- a/src/deployments/cdk/src/deployments/config/create.ts
+++ b/src/deployments/cdk/src/deployments/config/create.ts
@@ -211,13 +211,15 @@ export function getRemediationParameters(params: {
           const replaceKey = remediationParams[key].match('{SEA::(.*)}')?.[1]!;
           reutrnParams[key] = {
             StaticValue: {
-              Values: [getParameterValue({
-                paramKey: replaceKey, 
-                outputs, 
-                config,
-                accountKey,
-                defaultRegion,
-              })],
+              Values: [
+                getParameterValue({
+                  paramKey: replaceKey,
+                  outputs,
+                  config,
+                  accountKey,
+                  defaultRegion,
+                }),
+              ],
             },
           };
         } else {
@@ -237,16 +239,16 @@ export function getConfigRuleParameters(params: {
   ruleParams: { [key: string]: string };
   outputs: StackOutput[];
   config: c.AcceleratorConfig;
-  accountKey: string,
-  defaultRegion: string,
+  accountKey: string;
+  defaultRegion: string;
 }): { [key: string]: string } {
   const { config, outputs, ruleParams, accountKey, defaultRegion } = params;
   Object.keys(ruleParams).map(key => {
     if (ruleParams[key].startsWith('${SEA::')) {
       const replaceKey = ruleParams[key].match('{SEA::(.*)}')?.[1]!;
       ruleParams[key] = getParameterValue({
-        paramKey: replaceKey, 
-        outputs, 
+        paramKey: replaceKey,
+        outputs,
         config,
         accountKey,
         defaultRegion,
@@ -257,11 +259,11 @@ export function getConfigRuleParameters(params: {
 }
 
 export function getParameterValue(props: {
-  paramKey: string,
-  outputs: StackOutput[],
-  config: c.AcceleratorConfig,
-  accountKey: string,
-  defaultRegion: string,
+  paramKey: string;
+  outputs: StackOutput[];
+  config: c.AcceleratorConfig;
+  accountKey: string;
+  defaultRegion: string;
 }): string {
   const { accountKey, config, outputs, paramKey, defaultRegion } = props;
   if (paramKey === 'LogArchiveAesBucket') {


### PR DESCRIPTION
- Using "AutomationAssumeRole" if customer provided in ssm document parametrs instead of PipelineRole.
- Passing Static values as SSM Document parametrs.
- Adding SEA:S3BucketEncryptionKey as parameter value, which will replace by KMS Key created for Account Bucket encryption.
- Adding SSM Document for Encrypting S3 Bucket if not encrypted.
- Adding AWS Config rule "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED" configuration to config example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
