### PR TITLE
fix(core): Using public ECR image for preDeploy to avoid Docker Throttling

### DIFF
--- a/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
+++ b/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
@@ -131,10 +131,9 @@ export class PrebuiltCdkDeployProject extends CdkDeployProjectBase {
     fs.writeFileSync(
       path.join(this.projectTmpDir, 'Dockerfile'),
       [
-        'FROM node:12-alpine3.11',
+        'FROM public.ecr.aws/bitnami/node:latest',
         // Install the package manager
         ...installPackageManagerCommands(props.packageManager).map(cmd => `RUN ${cmd}`),
-        `RUN mkdir ${appDir}`,
         `WORKDIR ${appDir}`,
         // Copy over the project root to the /app directory
         `ADD . ${appDir}/`,

--- a/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
+++ b/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
@@ -131,7 +131,7 @@ export class PrebuiltCdkDeployProject extends CdkDeployProjectBase {
     fs.writeFileSync(
       path.join(this.projectTmpDir, 'Dockerfile'),
       [
-        'FROM public.ecr.aws/bitnami/node:latest',
+        'FROM public.ecr.aws/bitnami/node:12',
         // Install the package manager
         ...installPackageManagerCommands(props.packageManager).map(cmd => `RUN ${cmd}`),
         `WORKDIR ${appDir}`,


### PR DESCRIPTION
- Using "public.ecr.aws/bitnami/node:latest" 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
