### PR TITLE
fix(core): Suspended accounts failure with respect to construct name  change of nested stacks in phase-2

### DIFF
--- a/src/deployments/cdk/src/apps/phase-2.ts
+++ b/src/deployments/cdk/src/apps/phase-2.ts
@@ -171,7 +171,7 @@ export async function deploy({ acceleratorConfig, accountStacks, accounts, conte
         continue;
       }
 
-      /***********************************************************
+      /* **********************************************************
        * Saving index in outputs to handle nasty bug occur while
        * changing construct name when account is suspended
        * *********************************************************/

--- a/src/lib/common-outputs/src/stack-output.ts
+++ b/src/lib/common-outputs/src/stack-output.ts
@@ -41,6 +41,7 @@ export function getStackOutput(outputs: StackOutput[], accountKey: string, outpu
 export interface StackJsonOutputFilter {
   accountKey?: string;
   outputType?: string;
+  region?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,6 +49,9 @@ export function getStackJsonOutput(outputs: StackOutput[], filter: StackJsonOutp
   return outputs
     .map(output => {
       if (filter.accountKey && output.accountKey !== filter.accountKey) {
+        return null;
+      }
+      if (filter.region && output.region !== filter.region) {
         return null;
       }
       try {

--- a/src/lib/common-outputs/src/vpc.ts
+++ b/src/lib/common-outputs/src/vpc.ts
@@ -14,6 +14,11 @@ export interface SecurityGroupsOutput {
   securityGroupIds: VpcSecurityGroupOutput[];
 }
 
+export interface SharedSecurityGroupIndexOutput {
+  vpcName: string;
+  index: number;
+}
+
 export const VpcSubnetOutput = t.interface({
   subnetId: t.string,
   subnetName: t.string,


### PR DESCRIPTION
- Maintaining same construct name when a account is suspended by saving in DDB outputsBy submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
