### PR TITLE
feat(core): Adding "storeAllOutputs" property in SM input

### DIFF
--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -155,6 +155,7 @@ export namespace InitialSetup {
           s3Bucket: props.configS3Bucket,
           branchName: props.configBranchName,
           acceleratorVersion: props.acceleratorVersion!,
+          'inputConfig.$': '$',
         },
         resultPath: '$.configuration',
       });
@@ -185,6 +186,7 @@ export namespace InitialSetup {
           'configCommitId.$': '$.configuration.configCommitId',
           'acceleratorVersion.$': '$.configuration.acceleratorVersion',
           outputTableName: outputsTable.tableName,
+          'storeAllOutputs.$': '$.configuration.storeAllOutputs',
         },
         resultPath: '$.configuration.baselineOutput',
       });


### PR DESCRIPTION
- Adding "storeAllOutputs" property in SM Input which will load all outputs from cfn stacks to DDB tables irrespective of existing entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
