### PR TITLE
fix(core): Storing rsysLog outputs in SSM for Remote Accounts

### DIFF
--- a/src/core/runtime/src/save-outputs-to-ssm/elb-outputs.ts
+++ b/src/core/runtime/src/save-outputs-to-ssm/elb-outputs.ts
@@ -105,14 +105,11 @@ export async function saveElbOutputs(props: SaveOutputsInput) {
   if (!accountConfig['populate-all-elbs-in-param-store']) {
     return;
   }
-  const additionalNlbAccountKeys = Array.from(
-    new Set([
-      ...config
-        .getVpcConfigs()
-        .filter(c => c.deployments?.rsyslog && c.accountKey !== account.key)
-        .map(al => al.accountKey),
-    ]),
-  );
+
+  const additionalNlbAccountKeys = config
+    .getRsysLogConfigs()
+    .filter(lb => lb.accountKey !== account.key)
+    .map(al => al.accountKey);
   const additionalAlbAccountKeys = config
     .getAlbConfigs()
     .filter(lb => lb.accountKey !== account.key)

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -917,6 +917,13 @@ export interface ResolvedMadConfig extends ResolvedConfigBase {
   mad: MadDeploymentConfig;
 }
 
+export interface ResolvedRsysLogConfig extends ResolvedConfigBase {
+  /**
+   * The rsyslog config to be deployed.
+   */
+  rsyslog: RsyslogConfig;
+}
+
 export class AcceleratorConfig implements t.TypeOf<typeof AcceleratorConfigType> {
   readonly 'global-options': GlobalOptionsConfig;
   readonly 'mandatory-account-configs': AccountsConfig;
@@ -1202,6 +1209,24 @@ export class AcceleratorConfig implements t.TypeOf<typeof AcceleratorConfigType>
       result.push({
         accountKey: key,
         mad,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Find all rsyslog configurations in mandatory accounts, workload accounts and organizational units.
+   */
+  getRsysLogConfigs(): ResolvedRsysLogConfig[] {
+    const result: ResolvedRsysLogConfig[] = [];
+    for (const [key, config] of this.getAccountConfigs()) {
+      const rsyslog = config.deployments?.rsyslog;
+      if (!rsyslog) {
+        continue;
+      }
+      result.push({
+        accountKey: key,
+        rsyslog,
       });
     }
     return result;


### PR DESCRIPTION
- Fix storing rsyslog outputs in SSM of remote accounts based on "populate-all-elbs-in-param-store".
- Previously failed to save outputs if remote account doesn't have VPCs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
