### PR TITLE
fix(core): MAD Failed to Deploy with 3 AZs in subnet

### DIFF
--- a/src/core/runtime/src/create-adconnector/create.ts
+++ b/src/core/runtime/src/create-adconnector/create.ts
@@ -116,7 +116,9 @@ export const handler = async (input: AdConnectorInput) => {
     let subnetIds: string[];
     if (adcConfig.azs.length > 0) {
       const adcAzs = adcConfig.azs.slice(0, 2);
-      subnetIds = vpcOutput.subnets.filter(s => adcAzs.includes(s.az)).map(s => s.subnetId);
+      subnetIds = vpcOutput.subnets
+        .filter(s => s.subnetName === adcConfig.subnet && adcAzs.includes(s.az))
+        .map(s => s.subnetId);
     } else {
       subnetIds = vpcOutput.subnets
         .filter(s => s.subnetName === adcConfig.subnet)

--- a/src/core/runtime/src/create-adconnector/create.ts
+++ b/src/core/runtime/src/create-adconnector/create.ts
@@ -113,7 +113,16 @@ export const handler = async (input: AdConnectorInput) => {
     }
 
     // Find subnets based on ADC Config subnet name
-    const subnetIds = vpcOutput.subnets.filter(s => s.subnetName === adcConfig.subnet).map(s => s.subnetId);
+    let subnetIds: string[];
+    if (adcConfig.azs.length > 0) {
+      const adcAzs = adcConfig.azs.slice(0, 2);
+      subnetIds = vpcOutput.subnets.filter(s => adcAzs.includes(s.az)).map(s => s.subnetId);
+    } else {
+      subnetIds = vpcOutput.subnets
+        .filter(s => s.subnetName === adcConfig.subnet)
+        .map(s => s.subnetId)
+        .slice(0, 2);
+    }
 
     const accountId = getAccountId(accounts, accountKey);
     if (!accountId) {

--- a/src/deployments/cdk/src/deployments/mad/step-2.ts
+++ b/src/deployments/cdk/src/deployments/mad/step-2.ts
@@ -65,7 +65,9 @@ function createActiveDirectory(props: MadStep2Props) {
     let subnetIds: string[];
     if (madConfig.azs.length > 0) {
       const madAzs = madConfig.azs.slice(0, 2);
-      subnetIds = vpcOutput.subnets.filter(s => madAzs.includes(s.az)).map(s => s.subnetId);
+      subnetIds = vpcOutput.subnets
+        .filter(s => s.subnetName === madConfig.subnet && madAzs.includes(s.az))
+        .map(s => s.subnetId);
     } else {
       subnetIds = vpcOutput.subnets
         .filter(s => s.subnetName === madConfig.subnet)

--- a/src/deployments/cdk/src/deployments/mad/step-2.ts
+++ b/src/deployments/cdk/src/deployments/mad/step-2.ts
@@ -62,7 +62,16 @@ function createActiveDirectory(props: MadStep2Props) {
     }
 
     const vpcId = vpcOutput.vpcId;
-    const subnetIds = vpcOutput.subnets.filter(s => s.subnetName === madConfig.subnet).map(s => s.subnetId);
+    let subnetIds: string[];
+    if (madConfig.azs.length > 0) {
+      const madAzs = madConfig.azs.slice(0, 2);
+      subnetIds = vpcOutput.subnets.filter(s => madAzs.includes(s.az)).map(s => s.subnetId);
+    } else {
+      subnetIds = vpcOutput.subnets
+        .filter(s => s.subnetName === madConfig.subnet)
+        .map(s => s.subnetId)
+        .slice(0, 2);
+    }
 
     const madPasswordSecretArn = getMadConfigRootPasswordSecretArn({
       acceleratorPrefix,

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -449,6 +449,7 @@ export const AdcConfigType = t.interface({
   deploy: t.boolean,
   'vpc-name': t.string,
   subnet: t.string,
+  azs: fromNullable(t.array(t.string), []),
   size: t.string,
   restrict_srcips: t.array(cidr),
   'connect-account-key': t.string,

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -338,6 +338,7 @@ export const MadConfigType = t.interface({
   'vpc-name': t.string,
   region: t.string,
   subnet: t.string,
+  azs: fromNullable(t.array(t.string), []),
   size: t.string,
   'dns-domain': t.string,
   'netbios-domain': t.string,


### PR DESCRIPTION
- Added new param "azs": string[] in deployments/mad and deployments/adc config
- If no azs specified consider first two azs in subnet config
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
