### PR TITLE
fix(core): Fixing CloudWatch Central logging configuration changes

### DIFF
--- a/src/deployments/cdk/src/deployments/central-services/step-1.ts
+++ b/src/deployments/cdk/src/deployments/central-services/step-1.ts
@@ -49,6 +49,10 @@ async function centralServicesSettingsInMaster(props: {
     accountIds.push(getAccountId(accounts, config['central-log-services'].account)!);
   }
 
+  if (accountIds.length === 0) {
+    return;
+  }
+
   // Enable Cross-Account CloudWatch access in Master account fot sub accounts
   const masterStack = accountStacks.getOrCreateAccountStack(config['aws-org-master'].account);
   await cloudWatchSettingsInMaster({

--- a/src/deployments/cdk/src/deployments/central-services/step-2.ts
+++ b/src/deployments/cdk/src/deployments/central-services/step-2.ts
@@ -89,6 +89,9 @@ export async function step2(props: CentralServicesStep2Props) {
       .map(a => {
         return getAccountId(accounts, a)!;
       });
+    if (monitoringAccountIds.length === 0) {
+      return;
+    }
     await centralLoggingShareDataSettings({
       scope: accountStack,
       monitoringAccountIds,

--- a/src/deployments/cdk/src/deployments/iam/create-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/create-role.ts
@@ -39,6 +39,8 @@ export async function createRole(stack: AccountStack) {
         'iam:TagRole',
         'iam:DeleteRole',
         'iam:UpdateAssumeRolePolicy',
+        'iam:ListAttachedRolePolicies',
+        'iam:DetachRolePolicy',
       ],
       resources: ['*'],
     }),

--- a/src/deployments/cdk/src/deployments/iam/create-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/create-role.ts
@@ -32,7 +32,14 @@ export async function createRole(stack: AccountStack) {
 
   role.addToPrincipalPolicy(
     new iam.PolicyStatement({
-      actions: ['iam:GetRole', 'iam:CreateRole', 'iam:AttachRolePolicy', 'iam:TagRole', 'iam:DeleteRole'],
+      actions: [
+        'iam:GetRole',
+        'iam:CreateRole',
+        'iam:AttachRolePolicy',
+        'iam:TagRole',
+        'iam:DeleteRole',
+        'iam:UpdateAssumeRolePolicy',
+      ],
       resources: ['*'],
     }),
   );

--- a/src/lib/custom-resources/cdk-iam-create-role/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-iam-create-role/runtime/src/index.ts
@@ -32,11 +32,13 @@ async function onCreate(event: CloudFormationCustomResourceEvent) {
         })
         .promise(),
     );
-    await throttlingBackOff(() => 
-      iam.updateAssumeRolePolicy({
-        RoleName: event.ResourceProperties.roleName,
-        PolicyDocument: buildPolicyDocument(event.ResourceProperties.accountIds),
-      }).promise(),
+    await throttlingBackOff(() =>
+      iam
+        .updateAssumeRolePolicy({
+          RoleName: event.ResourceProperties.roleName,
+          PolicyDocument: buildPolicyDocument(event.ResourceProperties.accountIds),
+        })
+        .promise(),
     );
   } catch (error) {
     if (error.code === 'NoSuchEntity') {

--- a/src/lib/custom-resources/cdk-iam-create-role/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-iam-create-role/runtime/src/index.ts
@@ -32,6 +32,12 @@ async function onCreate(event: CloudFormationCustomResourceEvent) {
         })
         .promise(),
     );
+    await throttlingBackOff(() => 
+      iam.updateAssumeRolePolicy({
+        RoleName: event.ResourceProperties.roleName,
+        PolicyDocument: buildPolicyDocument(event.ResourceProperties.accountIds),
+      }).promise(),
+    );
   } catch (error) {
     if (error.code === 'NoSuchEntity') {
       console.log(error.message);


### PR DESCRIPTION
- Changing CloudWatch central logging configuration "accountConfig/cwl:false/true".
- Fixing for no CWL central accounts in Ops, Security and log account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
