### PR TITLE
fix(core): Removing StackSet for installing Pipeline role in Org Accounts

### DIFF
--- a/src/core/cdk/src/assets/execution-role.template.json
+++ b/src/core/cdk/src/assets/execution-role.template.json
@@ -31,6 +31,13 @@
               "Principal": {
                 "Service": "ssm.amazonaws.com"
               }
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "cloudformation.amazonaws.com"
+              }
             }
           ],
           "Version": "2012-10-17"

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -426,7 +426,7 @@ export namespace InitialSetup {
       const installExecRolesInAccounts = new sfn.Map(this, `Install Execution Roles Map`, {
         itemsPath: '$.accounts',
         resultPath: 'DISCARD',
-        maxConcurrency: 1,
+        maxConcurrency: 40,
         parameters: {
           'accountId.$': '$$.Map.Item.Value',
           'organizationAdmiRole.$': '$.organizationAdmiRole',

--- a/src/core/cdk/src/tasks/create-stack-task.ts
+++ b/src/core/cdk/src/tasks/create-stack-task.ts
@@ -9,6 +9,7 @@ export namespace CreateStackTask {
     role: iam.IRole;
     lambdaCode: lambda.Code;
     waitSeconds?: number;
+    suffix?: string;
   }
 }
 
@@ -19,7 +20,7 @@ export class CreateStackTask extends sfn.StateMachineFragment {
   constructor(scope: cdk.Construct, id: string, props: CreateStackTask.Props) {
     super(scope, id);
 
-    const { role, lambdaCode, waitSeconds = 10 } = props;
+    const { role, lambdaCode, suffix, waitSeconds = 10 } = props;
 
     role.addToPrincipalPolicy(
       new iam.PolicyStatement({
@@ -36,7 +37,7 @@ export class CreateStackTask extends sfn.StateMachineFragment {
       }),
     );
 
-    const deployTask = new CodeTask(scope, `Deploy`, {
+    const deployTask = new CodeTask(scope, `Deploy${suffix || ''}`, {
       resultPath: 'DISCARD',
       functionProps: {
         role,
@@ -47,7 +48,7 @@ export class CreateStackTask extends sfn.StateMachineFragment {
 
     const verifyTaskResultPath = '$.verify';
     const verifyTaskStatusPath = `${verifyTaskResultPath}.status`;
-    const verifyTask = new CodeTask(scope, 'Verify', {
+    const verifyTask = new CodeTask(scope, `Verify${suffix || ''}`, {
       resultPath: verifyTaskResultPath,
       functionProps: {
         role,
@@ -56,19 +57,19 @@ export class CreateStackTask extends sfn.StateMachineFragment {
       },
     });
 
-    const waitTask = new sfn.Wait(scope, 'Wait', {
+    const waitTask = new sfn.Wait(scope, `Wait${suffix || ''}`, {
       time: sfn.WaitTime.duration(cdk.Duration.seconds(waitSeconds)),
     });
 
-    const pass = new sfn.Pass(this, 'Succeeded');
+    const pass = new sfn.Pass(this, `Succeeded${suffix || ''}`);
 
-    const fail = new sfn.Fail(this, 'Failed');
+    const fail = new sfn.Fail(this, `Failed${suffix || ''}`);
 
     const chain = sfn.Chain.start(deployTask)
       .next(waitTask)
       .next(verifyTask)
       .next(
-        new sfn.Choice(scope, 'Choice')
+        new sfn.Choice(scope, `Choice${suffix || ''}`)
           .when(sfn.Condition.stringEquals(verifyTaskStatusPath, 'SUCCESS'), pass)
           .when(sfn.Condition.stringEquals(verifyTaskStatusPath, 'IN_PROGRESS'), waitTask)
           .otherwise(fail)

--- a/src/core/runtime/src/create-stack/create.ts
+++ b/src/core/runtime/src/create-stack/create.ts
@@ -1,18 +1,21 @@
 import { CloudFormation, objectToCloudFormationParameters } from '@aws-accelerator/common/src/aws/cloudformation';
 import { StackTemplateLocation, getTemplateBody } from '../create-stack-set/create-stack-set';
+import { STS } from '@aws-accelerator/common/src/aws/sts';
 
 interface CreateStackInput {
   stackName: string;
   stackCapabilities: string[];
   stackParameters: { [key: string]: string };
   stackTemplate: StackTemplateLocation;
+  accountId?: string;
+  assumedRoleName?: string;
 }
 
 export const handler = async (input: CreateStackInput) => {
   console.log(`Creating stack...`);
   console.log(JSON.stringify(input, null, 2));
 
-  const { stackName, stackCapabilities, stackParameters, stackTemplate } = input;
+  const { stackName, stackCapabilities, stackParameters, stackTemplate, accountId, assumedRoleName } = input;
 
   console.debug(`Creating stack template`);
   console.debug(stackTemplate);
@@ -20,7 +23,14 @@ export const handler = async (input: CreateStackInput) => {
   // Load the template body from the given location
   const templateBody = await getTemplateBody(stackTemplate);
 
-  const cfn = new CloudFormation();
+  let cfn: CloudFormation;
+  if (accountId && assumedRoleName) {
+    const sts = new STS();
+    const credentials = await sts.getCredentialsForAccountAndRole(accountId, assumedRoleName);
+    cfn = new CloudFormation(credentials);
+  } else {
+    cfn = new CloudFormation();
+  }
   await cfn.createOrUpdateStack({
     StackName: stackName,
     TemplateBody: templateBody,

--- a/src/core/runtime/src/create-stack/verify.ts
+++ b/src/core/runtime/src/create-stack/verify.ts
@@ -1,19 +1,29 @@
 import { CloudFormation } from '@aws-accelerator/common/src/aws/cloudformation';
+import { STS } from '@aws-accelerator/common/src/aws/sts';
 
 const SUCCESS_STATUSES = ['CREATE_COMPLETE', 'UPDATE_COMPLETE'];
 const FAILED_STATUSES = ['CREATE_FAILED', 'ROLLBACK_COMPLETE', 'ROLLBACK_FAILED', 'UPDATE_ROLLBACK_COMPLETE'];
 
 interface CheckStepInput {
   stackName?: string;
+  accountId?: string;
+  assumedRoleName?: string;
 }
 
 export const handler = async (input: Partial<CheckStepInput>) => {
   console.log(`Verifying stack with parameters ${JSON.stringify(input, null, 2)}`);
 
-  const { stackName } = input;
+  const { stackName, accountId, assumedRoleName } = input;
 
   // Deploy the stack using the assumed role in the current region
-  const cfn = new CloudFormation();
+  let cfn: CloudFormation;
+  if (accountId && assumedRoleName) {
+    const sts = new STS();
+    const credentials = await sts.getCredentialsForAccountAndRole(accountId, assumedRoleName);
+    cfn = new CloudFormation(credentials);
+  } else {
+    cfn = new CloudFormation();
+  }
   const stack = await cfn.describeStack(stackName!);
   if (!stack) {
     return {

--- a/src/core/runtime/src/get-baseline-step.ts
+++ b/src/core/runtime/src/get-baseline-step.ts
@@ -20,6 +20,7 @@ export interface GetBaseelineOutput {
   baseline: string;
   storeAllOutputs: boolean;
   phases: number[];
+  organizationAdmiRole: string;
 }
 
 const dynamoDB = new DynamoDB();
@@ -68,5 +69,6 @@ export const handler = async (input: GetBaseLineInput): Promise<GetBaseelineOutp
     baseline,
     storeAllOutputs: runStoreAllOutputs,
     phases: [-1, 0, 1, 2, 3],
+    organizationAdmiRole: globalOptionsConfig['organization-admin-role'] || 'AWSCloudFormationStackSetExecutionRole',
   };
 };

--- a/src/core/runtime/src/load-configuration-step.ts
+++ b/src/core/runtime/src/load-configuration-step.ts
@@ -4,6 +4,7 @@ export interface LoadConfigurationInput {
   configFilePath: string;
   configRepositoryName: string;
   configCommitId: string;
+  organizationAdmiRole: string;
   baseline?: BaseLineType;
   acceleratorVersion?: string;
   configRootFilePath?: string;


### PR DESCRIPTION
- Creating CloudFormation stack for creating PipelineRole in Org Accounts by assuming role mentioned in  "global-options/organization-admin-role".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
