### PR TITLE
fix(core): SSM ParamStore history truncated for installedVersion

### DIFF
--- a/src/core/runtime/src/enable-trusted-access-for-services-step.ts
+++ b/src/core/runtime/src/enable-trusted-access-for-services-step.ts
@@ -86,6 +86,9 @@ export const handler = async (input: EnableTrustedAccessForServicesInput) => {
   console.log('Security account registered as delegated administrator for Guard Duty in the organization.');
 
   // Get all the parameter history versions from SSM parameter store
-  const installedVersionParam = await ssm.getParameter('/accelerator/installed-version');
-  return installedVersionParam.Parameter?.Value || '<1.2.2';
+  const firstInstalVersionParam = await ssm.getParameter('/accelerator/first-version');
+  if (!firstInstalVersionParam.Parameter || !firstInstalVersionParam.Parameter.Value) {
+    throw new Error('Missing value in "/accelerator/first-version"');
+  }
+  return firstInstalVersionParam.Parameter?.Value;
 };

--- a/src/core/runtime/src/enable-trusted-access-for-services-step.ts
+++ b/src/core/runtime/src/enable-trusted-access-for-services-step.ts
@@ -86,9 +86,6 @@ export const handler = async (input: EnableTrustedAccessForServicesInput) => {
   console.log('Security account registered as delegated administrator for Guard Duty in the organization.');
 
   // Get all the parameter history versions from SSM parameter store
-  const parameterHistoryList = await ssm.getParameterHistory('/accelerator/version');
-  // Finding the first entry of the parameter version
-  const installerVersion = parameterHistoryList.find(p => p.Version === 1);
-  const installerVersionValue = JSON.parse(installerVersion!.Value!);
-  return !installerVersionValue.AcceleratorVersion ? '<1.2.2' : installerVersionValue.AcceleratorVersion;
+  const installedVersionParam = await ssm.getParameter('/accelerator/installed-version');
+  return installedVersionParam.Parameter?.Value || '<1.2.2';
 };

--- a/src/installer/cdk/src/index.ts
+++ b/src/installer/cdk/src/index.ts
@@ -238,7 +238,7 @@ async function main() {
 
   stateMachineExecutionRole.addToPrincipalPolicy(
     new iam.PolicyStatement({
-      actions: ['ssm:PutParameter'],
+      actions: ['ssm:PutParameter', 'ssm:GetParameter', 'ssm:GetParameterHistory'],
       resources: ['*'],
     }),
   );


### PR DESCRIPTION
- Creating "/accelerator/installed-version" SSM ParamStore and inserting version:1 installed version into it.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
