### PR TITLE
fix(core): File copy mechanism broken

### DIFF
--- a/reference-artifacts/SCPs/FullAWSAccess.json
+++ b/reference-artifacts/SCPs/FullAWSAccess.json
@@ -5,6 +5,11 @@
       "Effect": "Allow",
       "Action": "*",
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "TestNewRepo"
     }
   ]
 }

--- a/reference-artifacts/SCPs/FullAWSAccess.json
+++ b/reference-artifacts/SCPs/FullAWSAccess.json
@@ -5,11 +5,6 @@
       "Effect": "Allow",
       "Action": "*",
       "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "*",
-      "Resource": "TestNewRepo"
     }
   ]
 }

--- a/src/deployments/cdk/src/deployments/artifacts/step-1.ts
+++ b/src/deployments/cdk/src/deployments/artifacts/step-1.ts
@@ -125,9 +125,6 @@ function uploadArtifacts(props: {
     artifactFolderName,
   );
 
-  // TODO Leave existing files in the folder
-  // TODO Do not override existing files
-  // See https://github.com/aws/aws-cdk/issues/953
   const s3Deployment = new s3deployment.BucketDeployment(
     accountStack,
     `${artifactName}ArtifactsDeployment${accountKey}`,

--- a/src/deployments/cdk/src/deployments/defaults/step-1.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-1.ts
@@ -79,12 +79,6 @@ function createCentralBucketCopy(props: DefaultsStep1Props) {
   const masterAccountConfig = config['global-options']['aws-org-master'];
   const masterAccountStack = accountStacks.getOrCreateAccountStack(masterAccountConfig.account);
 
-  // Get the location of the original central bucket
-  const centralBucketName = config['global-options']['central-bucket'];
-  const centralBucket = s3.Bucket.fromBucketAttributes(masterAccountStack, 'CentralBucket', {
-    bucketName: centralBucketName,
-  });
-
   const keyAlias = createEncryptionKeyName('Config-Key');
   const encryptionKey = new kms.Key(masterAccountStack, 'CentralBucketKey', {
     alias: `alias/${keyAlias}`,
@@ -130,17 +124,6 @@ function createCentralBucketCopy(props: DefaultsStep1Props) {
       principals: accountPrincipals,
     }),
   );
-
-  // Copy files from source to destination
-  const copyFiles = new S3CopyFiles(masterAccountStack, 'CopyFiles', {
-    roleName: createRoleName('S3CopyFiles'),
-    sourceBucket: centralBucket,
-    destinationBucket: bucket,
-    deleteSourceObjects: false,
-    deleteSourceBucket: false,
-    forceUpdate: true,
-  });
-  copyFiles.node.addDependency(bucket);
 
   new CfnCentralBucketOutput(masterAccountStack, 'CentralBucketOutput', {
     bucketArn: bucket.bucketArn,


### PR DESCRIPTION
Changing current file copy order as following.
- Performing s3 deployment using aws sync to get latest from repo
- After bucket deployment s3copyfiles to get latest file from customer s3 bucket.

By changing order we will be able to copy files provided in customer bucket which are not in repo to phase0 central bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
