### PR TITLE
fix(core): Handling both inbound and outbound to be false in both resolvers

### DIFF
--- a/src/deployments/cdk/src/deployments/central-endpoints/step-3.ts
+++ b/src/deployments/cdk/src/deployments/central-endpoints/step-3.ts
@@ -170,6 +170,9 @@ export async function step3(props: CentralEndpointsStep3Props) {
       ...(resolverRegionoutputs.rules?.madRules || []),
       ...(resolverRegionoutputs.rules?.onPremRules || []),
     ];
+    if (ruleIds.length === 0) {
+      continue;
+    }
     new AssociateResolverRules(accountStack, constructName, {
       resolverRuleIds: ruleIds,
       roleArn: roleOutput.roleArn,

--- a/src/deployments/cdk/src/deployments/central-endpoints/step-3.ts
+++ b/src/deployments/cdk/src/deployments/central-endpoints/step-3.ts
@@ -166,7 +166,10 @@ export async function step3(props: CentralEndpointsStep3Props) {
       continue;
     }
 
-    const ruleIds = [...resolverRegionoutputs.rules?.madRules!, ...resolverRegionoutputs.rules?.onPremRules!];
+    const ruleIds = [
+      ...(resolverRegionoutputs.rules?.madRules || []),
+      ...(resolverRegionoutputs.rules?.onPremRules || []),
+    ];
     new AssociateResolverRules(accountStack, constructName, {
       resolverRuleIds: ruleIds,
       roleArn: roleOutput.roleArn,


### PR DESCRIPTION
- Handling both inbound and outbound to be false in both resolvers
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
