### PR TITLE
fix(core): Fixing SSM-Document-Share

### DIFF
--- a/src/deployments/cdk/src/deployments/security-hub/step-1.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-1.ts
@@ -12,6 +12,14 @@ export interface SecurityHubStep1Props {
   outputs: StackOutput[];
 }
 
+/**
+ *
+ * @param props
+ * @returns
+ *
+ * Enables SecurityHub in Audit Account also send invites
+ * to sub accounts in all regions excluding security-hub-excl-regions
+ */
 export async function step1(props: SecurityHubStep1Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
@@ -36,7 +44,12 @@ export async function step1(props: SecurityHubStep1Props) {
     return;
   }
 
+  const securityHubExclRegions = globalOptions['central-security-services']['security-hub-excl-regions'] || [];
   for (const region of regions) {
+    if (securityHubExclRegions.includes(region)) {
+      console.info(`Security Hub is disabled in region "${region}" based on global-options/security-hub-excl-regions'`);
+      continue;
+    }
     const securityMasterAccountStack = accountStacks.tryGetOrCreateAccountStack(securityAccountKey, region);
     if (!securityMasterAccountStack) {
       console.warn(`Cannot find security stack in region ${region}`);

--- a/src/deployments/cdk/src/deployments/security-hub/step-1.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-1.ts
@@ -23,6 +23,9 @@ export interface SecurityHubStep1Props {
 export async function step1(props: SecurityHubStep1Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
+  if (!globalOptions['central-security-services']['security-hub']) {
+    return;
+  }
   const regions = globalOptions['supported-regions'];
   const securityAccountKey = config.getMandatoryAccountKey('central-security');
   const securityMasterAccount = accounts.find(a => a.key === securityAccountKey);

--- a/src/deployments/cdk/src/deployments/security-hub/step-2.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-2.ts
@@ -11,7 +11,11 @@ export interface SecurityHubStep2Props {
   accountStacks: AccountStacks;
   outputs: StackOutput[];
 }
-
+/**
+ *
+ * @param props
+ * Accept invites in sub accounts in all regions excluding security-hub-excl-regions
+ */
 export async function step2(props: SecurityHubStep2Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
@@ -33,7 +37,14 @@ export async function step2(props: SecurityHubStep2Props) {
       continue;
     }
 
+    const securityHubExclRegions = globalOptions['central-security-services']['security-hub-excl-regions'] || [];
     for (const region of regions) {
+      if (securityHubExclRegions.includes(region)) {
+        console.info(
+          `Security Hub is disabled in region "${region}" based on global-options/security-hub-excl-regions'`,
+        );
+        continue;
+      }
       const memberAccountStack = accountStacks.tryGetOrCreateAccountStack(account.key, region);
       if (!memberAccountStack) {
         console.warn(`Cannot find account stack ${account.key} in region ${region}`);

--- a/src/deployments/cdk/src/deployments/security-hub/step-2.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-2.ts
@@ -19,6 +19,9 @@ export interface SecurityHubStep2Props {
 export async function step2(props: SecurityHubStep2Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
+  if (!globalOptions['central-security-services']['security-hub']) {
+    return;
+  }
   const regions = globalOptions['supported-regions'];
   const securityAccountKey = config.getMandatoryAccountKey('central-security');
   const securityMasterAccount = accounts.find(a => a.key === securityAccountKey);

--- a/src/deployments/cdk/src/deployments/security-hub/step-3.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-3.ts
@@ -11,7 +11,12 @@ export interface SecurityHubStep3Props {
   accountStacks: AccountStacks;
   outputs: StackOutput[];
 }
-
+/**
+ *
+ * @param props
+ * Disable SecurityHub Controls in all accounts all regions excluding security-hub-excl-regions
+ * Disable based on "global-options/security-hub-frameworks/standards/[*]/controls-to-disable"
+ */
 export async function step3(props: SecurityHubStep3Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
@@ -27,7 +32,14 @@ export async function step3(props: SecurityHubStep3Props) {
       continue;
     }
 
+    const securityHubExclRegions = globalOptions['central-security-services']['security-hub-excl-regions'] || [];
     for (const region of regions) {
+      if (securityHubExclRegions.includes(region)) {
+        console.info(
+          `Security Hub is disabled in region "${region}" based on global-options/security-hub-excl-regions'`,
+        );
+        continue;
+      }
       const accountStack = accountStacks.tryGetOrCreateAccountStack(account.key, region);
       if (!accountStack) {
         console.warn(`Cannot find account stack ${account.key} in region ${region}`);

--- a/src/deployments/cdk/src/deployments/security-hub/step-3.ts
+++ b/src/deployments/cdk/src/deployments/security-hub/step-3.ts
@@ -20,8 +20,10 @@ export interface SecurityHubStep3Props {
 export async function step3(props: SecurityHubStep3Props) {
   const { accounts, accountStacks, config, outputs } = props;
   const globalOptions = config['global-options'];
+  if (!globalOptions['central-security-services']['security-hub']) {
+    return;
+  }
   const regions = globalOptions['supported-regions'];
-
   for (const account of accounts) {
     const securityHubRoleOutput = IamRoleOutputFinder.tryFindOneByName({
       outputs,

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -679,6 +679,7 @@ export const CentralServicesConfigType = t.interface({
   account: NonEmptyString,
   region: NonEmptyString,
   'security-hub': fromNullable(t.boolean, false),
+  'security-hub-excl-regions': optional(t.array(t.string)),
   guardduty: fromNullable(t.boolean, false),
   'guardduty-excl-regions': optional(t.array(t.string)),
   'guardduty-s3': fromNullable(t.boolean, false),

--- a/src/lib/custom-resources/cdk-cfn-utils/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-cfn-utils/cdk/index.ts
@@ -27,3 +27,7 @@ export const isThrottlingError = (e: any) =>
 export async function delay(ms: number) {
   return new Promise((resolve, reject) => setTimeout(resolve, ms));
 }
+
+export function paginate<T>(input: T[], pageNumber: number, pageSize: number): T[] {
+  return input.slice((pageNumber - 1) * pageSize, pageNumber * pageSize);
+}

--- a/src/lib/custom-resources/cdk-guardduty-admin-setup/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-guardduty-admin-setup/runtime/src/index.ts
@@ -13,7 +13,7 @@ const physicalResourceId = 'GaurdDutyDeligatedAdminAccountSetup';
 const guardduty = new AWS.GuardDuty();
 
 // Guardduty CreateMembers, UpdateMembers and DeleteMembers apis only supports max 50 accounts per request
-const pageSize = 50;
+const pageSize = 3;
 
 export interface AccountDetail {
   AccountId: string;

--- a/src/lib/custom-resources/cdk-guardduty-admin-setup/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-guardduty-admin-setup/runtime/src/index.ts
@@ -13,7 +13,7 @@ const physicalResourceId = 'GaurdDutyDeligatedAdminAccountSetup';
 const guardduty = new AWS.GuardDuty();
 
 // Guardduty CreateMembers, UpdateMembers and DeleteMembers apis only supports max 50 accounts per request
-const pageSize = 3;
+const pageSize = 50;
 
 export interface AccountDetail {
   AccountId: string;
@@ -110,7 +110,7 @@ async function createMembers(memberAccounts: AccountDetail[], detectorId: string
           })
           .promise(),
       );
-      currentAccounts = paginate(memberAccounts, pageNumber, pageSize);
+      currentAccounts = paginate(memberAccounts, ++pageNumber, pageSize);
     }
   } catch (error) {
     console.error(
@@ -187,7 +187,7 @@ async function updateMemberDataSource(memberAccounts: AccountDetail[], detectorI
           })
           .promise(),
       );
-      currentAccounts = paginate(memberAccounts, pageNumber, pageSize);
+      currentAccounts = paginate(memberAccounts, ++pageNumber, pageSize);
     }
   } catch (error) {
     console.error(`Error Occurred while updateMemberDetectors of GuardDuty ${error.code}: ${error.message}`);
@@ -229,7 +229,7 @@ async function deleteMembers(memberAccounts: AccountDetail[], detectorId: string
           })
           .promise(),
       );
-      currentAccounts = paginate(memberAccounts, pageNumber, pageSize);
+      currentAccounts = paginate(memberAccounts, ++pageNumber, pageSize);
     }
   } catch (error) {
     console.error(

--- a/src/lib/custom-resources/cdk-ssm-document-share/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-ssm-document-share/runtime/src/index.ts
@@ -15,7 +15,7 @@ export interface HandlerProperties {
 }
 
 // SSM modifyDocumentPermission api only supports max 20 accounts per request
-const pageSize = 20;
+const pageSize = 3;
 const ssm = new AWS.SSM();
 
 export const handler = errorHandler(onEvent);

--- a/src/lib/custom-resources/cdk-ssm-document-share/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-ssm-document-share/runtime/src/index.ts
@@ -15,7 +15,7 @@ export interface HandlerProperties {
 }
 
 // SSM modifyDocumentPermission api only supports max 20 accounts per request
-const pageSize = 3;
+const pageSize = 20;
 const ssm = new AWS.SSM();
 
 export const handler = errorHandler(onEvent);


### PR DESCRIPTION
- Fixing number of accountIds passing to ssm modify-document-permission
- Fixing number of accounts passing to GuardDuty createMembers, updateMembers and deleteMembers
- Adding security-hub-excl-regions and not enabling security hub in those regions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.