### PR TITLE
added error catching for failed log metrics

### DIFF
--- a/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
@@ -73,6 +73,7 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
       );
     } catch (error) {
       console.error(`Did not find LogGroup ${logGroupName}`);
+    }
   }
 
   return {

--- a/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
@@ -53,26 +53,26 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
       .promise(),
   );
   if (logGroup.logGroups?.length !== 0) {
-      await throttlingBackOff(() =>
-        logs
-          .putMetricFilter({
-            filterName,
-            filterPattern,
-            logGroupName,
-            metricTransformations: [
-              {
-                metricName,
-                metricNamespace,
-                metricValue,
-                defaultValue,
-              },
-            ],
-          })
-          .promise(),
-      );
-    } else {
-      throw(`Did not find LogGroup ${logGroupName}`);
-    }
+    await throttlingBackOff(() =>
+      logs
+        .putMetricFilter({
+          filterName,
+          filterPattern,
+          logGroupName,
+          metricTransformations: [
+            {
+              metricName,
+              metricNamespace,
+              metricValue,
+              defaultValue,
+            },
+          ],
+        })
+        .promise(),
+    );
+  } else {
+    throw `Did not find LogGroup ${logGroupName}`;
+  }
 
   return {
     physicalResourceId: metricName,

--- a/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
@@ -71,7 +71,7 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
         .promise(),
     );
   } else {
-    throw `Did not find LogGroup ${logGroupName}`;
+    throw new Error(`Did not find LogGroup "${logGroupName}"`);
   }
 
   return {

--- a/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
@@ -53,25 +53,26 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
       .promise(),
   );
   if (logGroup.logGroups?.length !== 0) {
-    await throttlingBackOff(() =>
-      logs
-        .putMetricFilter({
-          filterName,
-          filterPattern,
-          logGroupName,
-          metricTransformations: [
-            {
-              metricName,
-              metricNamespace,
-              metricValue,
-              defaultValue,
-            },
-          ],
-        })
-        .promise(),
-    );
-  } else {
-    console.warn(`Did not find LogGroup ${logGroupName}`);
+    try {
+      await throttlingBackOff(() =>
+        logs
+          .putMetricFilter({
+            filterName,
+            filterPattern,
+            logGroupName,
+            metricTransformations: [
+              {
+                metricName,
+                metricNamespace,
+                metricValue,
+                defaultValue,
+              },
+            ],
+          })
+          .promise(),
+      );
+    } catch (error) {
+      console.error(`Did not find LogGroup ${logGroupName}`);
   }
 
   return {

--- a/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-logs-metric-filter/runtime/src/index.ts
@@ -53,7 +53,6 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
       .promise(),
   );
   if (logGroup.logGroups?.length !== 0) {
-    try {
       await throttlingBackOff(() =>
         logs
           .putMetricFilter({
@@ -71,10 +70,9 @@ async function onCreateOrUpdate(event: CloudFormationCustomResourceEvent) {
           })
           .promise(),
       );
-    } catch (error) {
-      console.error(`Did not find LogGroup ${logGroupName}`);
+    } else {
+      throw(`Did not find LogGroup ${logGroupName}`);
     }
-  }
 
   return {
     physicalResourceId: metricName,


### PR DESCRIPTION
It is possible to define non-existent log groups in the metrics definitions in the accelerator config file. These metrics are used in alarms which are configured to be "OK" if there is missing data (i.e. no metric information). This then means that the alarms will never trigger missing the security event. To resolve this the accelerator should not WARN on a missing log group when creating the metric but instead ERROR and fail the deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
