### PR TITLE
fix(core): Minor Security Enhancements

### DIFF
--- a/src/deployments/cdk/src/common/interface-endpoints.ts
+++ b/src/deployments/cdk/src/common/interface-endpoints.ts
@@ -7,6 +7,14 @@ export interface InterfaceEndpointProps {
   vpcId: string;
   vpcRegion: string;
   subnetIds: string[];
+  allowedCidrs?: string[];
+  ports?: string[];
+}
+
+enum ProtocolPrefix {
+  TCP = 'TCP:',
+  UDP = 'UDP:',
+  ICMP = 'ICMP:',
 }
 
 /**
@@ -18,33 +26,40 @@ export class InterfaceEndpoint extends cdk.Construct {
   constructor(scope: cdk.Construct, id: string, props: InterfaceEndpointProps) {
     super(scope, id);
 
-    const { serviceName, vpcId, vpcRegion, subnetIds } = props;
-
+    const { serviceName, vpcId, vpcRegion, subnetIds, allowedCidrs, ports } = props;
+    const securityGroupIngress: ec2.CfnSecurityGroup.IngressProperty[] = [];
+    console.log(serviceName, allowedCidrs, ports);
+    for (const ingressCidr of allowedCidrs || ['0.0.0.0/0']) {
+      for (const endpointPort of ports || ['TCP:443']) {
+        let ipProtocol: ec2.Protocol;
+        let port: number;
+        if (endpointPort.startsWith(ProtocolPrefix.TCP)) {
+          port = parseInt(endpointPort.split(ProtocolPrefix.TCP).pop()!, 10);
+          ipProtocol = ec2.Protocol.TCP;
+        } else if (endpointPort.startsWith(ProtocolPrefix.UDP)) {
+          port = parseInt(endpointPort.split(ProtocolPrefix.UDP).pop()!, 10);
+          ipProtocol = ec2.Protocol.UDP;
+        } else if (endpointPort.startsWith(ProtocolPrefix.ICMP)) {
+          port = parseInt(endpointPort.split(ProtocolPrefix.ICMP).pop()!, 10);
+          ipProtocol = ec2.Protocol.ICMP;
+        } else {
+          port = 443;
+          ipProtocol = ec2.Protocol.TCP;
+        }
+        securityGroupIngress.push({
+          ipProtocol,
+          cidrIp: ingressCidr,
+          toPort: port,
+          fromPort: port,
+        });
+      }
+    }
     // Create a new security groupo per endpoint
     const securityGroup = new ec2.CfnSecurityGroup(this, `ep_${serviceName}`, {
       vpcId,
       groupDescription: `AWS Private Endpoint Zone - ${serviceName}`,
       groupName: `ep_${serviceName}_sg`,
-      securityGroupIngress: [
-        {
-          ipProtocol: ec2.Protocol.ALL,
-          cidrIp: '0.0.0.0/0',
-        },
-        {
-          ipProtocol: ec2.Protocol.ALL,
-          cidrIpv6: '0::/0',
-        },
-      ],
-      securityGroupEgress: [
-        {
-          ipProtocol: ec2.Protocol.ALL,
-          cidrIp: '0.0.0.0/0',
-        },
-        {
-          ipProtocol: ec2.Protocol.ALL,
-          cidrIpv6: '0::/0',
-        },
-      ],
+      securityGroupIngress,
     });
 
     const endpoint = new ec2.CfnVPCEndpoint(this, 'Endpoint', {

--- a/src/deployments/cdk/src/common/interface-endpoints.ts
+++ b/src/deployments/cdk/src/common/interface-endpoints.ts
@@ -28,7 +28,6 @@ export class InterfaceEndpoint extends cdk.Construct {
 
     const { serviceName, vpcId, vpcRegion, subnetIds, allowedCidrs, ports } = props;
     const securityGroupIngress: ec2.CfnSecurityGroup.IngressProperty[] = [];
-    console.log(serviceName, allowedCidrs, ports);
     for (const ingressCidr of allowedCidrs || ['0.0.0.0/0']) {
       for (const endpointPort of ports || ['TCP:443']) {
         let ipProtocol: ec2.Protocol;
@@ -60,6 +59,13 @@ export class InterfaceEndpoint extends cdk.Construct {
       groupDescription: `AWS Private Endpoint Zone - ${serviceName}`,
       groupName: `ep_${serviceName}_sg`,
       securityGroupIngress,
+      // Adding Egress '127.0.0.1/32' to avoid default Egress rule
+      securityGroupEgress: [
+        {
+          ipProtocol: ec2.Protocol.ALL,
+          cidrIp: '127.0.0.1/32',
+        },
+      ],
     });
 
     const endpoint = new ec2.CfnVPCEndpoint(this, 'Endpoint', {

--- a/src/deployments/cdk/src/deployments/vpc/step-3.ts
+++ b/src/deployments/cdk/src/deployments/vpc/step-3.ts
@@ -31,6 +31,7 @@ export async function step3(props: VpcStep3Props) {
   const allStaticResources = StaticResourcesOutputFinder.findAll({
     outputs,
   }).filter(sr => sr.resourceType === RESOURCE_TYPE);
+  const portOverrides = config['global-options']['endpoint-port-orverides'];
 
   const accountStaticResourcesConfig: { [accountKey: string]: StaticResourcesOutput[] } = {};
   const accountRegionExistingResources: {
@@ -163,7 +164,6 @@ export async function step3(props: VpcStep3Props) {
         console.error(`Cannot find account stack ${accountKey}: ${vpcConfig.region}, while Associating Resolver Rules`);
         continue;
       }
-
       const interfaceEndpoint = new InterfaceEndpoint(
         accountStack,
         `Endpoint-${vpcConfig.name}-${pascalCase(endpoint)}`,
@@ -172,6 +172,8 @@ export async function step3(props: VpcStep3Props) {
           vpcId: vpcOutput.vpcId,
           vpcRegion: vpcConfig.region,
           subnetIds: vpcOutput.subnets.filter(sn => sn.subnetName === endpointsConfig.subnet).map(s => s.subnetId),
+          allowedCidrs: endpointsConfig['allowed-cidrs']?.map(c => c.toCidrString()),
+          ports: portOverrides?.[endpoint],
         },
       );
 

--- a/src/installer/cdk/src/index.ts
+++ b/src/installer/cdk/src/index.ts
@@ -122,7 +122,7 @@ async function main() {
   installerProjectRole.addToPrincipalPolicy(
     new iam.PolicyStatement({
       actions: ['sts:AssumeRole'],
-      resources: [`arn:aws:iam::${cdk.Aws.ACCOUNT_ID}:role/*`],
+      resources: [`arn:aws:iam::${cdk.Aws.ACCOUNT_ID}:role/cdk-*`],
     }),
   );
 

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -143,6 +143,7 @@ export const InterfaceEndpointName = t.string; // TODO Define all endpoints here
 export const InterfaceEndpointConfig = t.interface({
   subnet: t.string,
   endpoints: t.array(InterfaceEndpointName),
+  'allowed-cidrs': optional(t.array(cidr)),
 });
 
 export const ResolversConfigType = t.interface({
@@ -856,6 +857,7 @@ export const GlobalOptionsConfigType = t.interface({
   'ssm-automation': fromNullable(t.array(SsmAutomation), []),
   'aws-config': optional(AwsConfig),
   'default-ssm-documents': fromNullable(t.array(t.string), []),
+  'endpoint-port-orverides': optional(t.record(t.string, t.array(t.string))),
 });
 
 export type CentralServicesConfig = t.TypeOf<typeof CentralServicesConfigType>;


### PR DESCRIPTION
1. Tighten permissions on: PBMMAccel-CB-Installer role
2. Tighten VPC interface endpoint security group permissions

Added new sections 

"global-options/endpoint-port-orverides": {
  "application-autoscaling": ["TCP:443", "TCP:8443", "TCP:943"],
  "codecommit": ["TCP:443", "UDP:9418"],
  "logs": ["TCP:443", "UDP:9418"]
}

"vpc/interface-endpoints/allowed-cidrs": ["10.0.0.0/8", "100.96.252.0/23"],


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
