### PR TITLE
Revert "feat(core) Enable account level SCP mgmt"

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/sample_snippets.md
+++ b/reference-artifacts/SAMPLE_CONFIGS/sample_snippets.md
@@ -705,17 +705,6 @@
 
 ---
 
-- Add SCP on a per account basis - add this to either workload or mandatory accounts sections
-
-```
-      "scps": [
-        "SCP 1",
-        "SCP 2"
-      ]
-```
-
----
-
 - Future description
 
 ```

--- a/src/core/runtime/src/add-scp-step.ts
+++ b/src/core/runtime/src/add-scp-step.ts
@@ -103,13 +103,6 @@ export const handler = async (input: AddScpInput) => {
     acceleratorPrefix,
   });
 
-  await scps.attachOrDetachPoliciesToAccounts({
-    existingPolicies,
-    configurationAccounts: accounts,
-    accountConfigs: config.getAccountConfigs(),
-    acceleratorPrefix,
-  });
-
   return {
     status: 'SUCCESS',
   };

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -592,7 +592,6 @@ export const MandatoryAccountConfigType = t.interface({
   'populate-all-elbs-in-param-store': fromNullable(t.boolean, false),
   'ssm-automation': fromNullable(t.array(SsmShareAutomation), []),
   'aws-config': fromNullable(t.array(AwsConfigAccountConfig), []),
-  scps: optional(t.array(t.string)),
 });
 
 export type MandatoryAccountConfig = t.TypeOf<typeof MandatoryAccountConfigType>;

--- a/src/lib/common/src/scp/index.ts
+++ b/src/lib/common/src/scp/index.ts
@@ -5,8 +5,6 @@ import { stringType } from 'aws-sdk/clients/iam';
 import { PolicySummary } from 'aws-sdk/clients/organizations';
 import { OrganizationalUnit } from '@aws-accelerator/common-outputs/src/organizations';
 import { additionalReplacements, replaceDefaults } from './../util/common';
-import { AccountConfig } from '@aws-accelerator/common-config/src';
-import { Account } from '@aws-accelerator/common-outputs/src/accounts';
 
 export const FULL_AWS_ACCESS_POLICY_NAME = 'FullAWSAccess';
 
@@ -264,76 +262,6 @@ export class ServiceControlPolicy {
 
         console.log(`Attaching ${ouPolicyName} to OU ${ouKey}`);
         await this.org.attachPolicy(policy.Id!, organizationalUnit.ouId);
-      }
-    }
-  }
-
-  /**
-   * Attach new or detach removed policies based on the account configuration.
-   */
-  async attachOrDetachPoliciesToAccounts(props: {
-    existingPolicies: PolicySummary[];
-    configurationAccounts: Account[];
-    accountConfigs: [string, AccountConfig][];
-    acceleratorPrefix: string;
-  }) {
-    const { existingPolicies, configurationAccounts, accountConfigs, acceleratorPrefix } = props;
-
-    for (const [accountKey, accountConfig] of accountConfigs) {
-      const Account = configurationAccounts.find(Account => Account.key === accountKey);
-      /**
-       * Check if scps key is set on account. If not, ignore as SCPs are being managed in the outside the installer.
-       */
-      if (accountConfig.scps == null) {
-        continue;
-      }
-
-      // Attach Accelerator SCPs to Accounts
-      if (!Account) {
-        console.warn(`Cannot find Account configuration with key "${accountKey}"`);
-        continue;
-      }
-
-      const accountPolicyNames = accountConfig.scps.map(policyName =>
-        ServiceControlPolicy.policyNameToAcceleratorPolicyName({ acceleratorPrefix, policyName }),
-      );
-
-      if (accountPolicyNames.length > 4) {
-        console.warn(`Maximum allowed SCP per Account is 5. Limit exceeded for Account ${accountKey}`);
-        continue;
-      }
-
-      // Find targets for this policy
-      const policyTargets = await this.org.listPoliciesForTarget({
-        Filter: 'SERVICE_CONTROL_POLICY',
-        TargetId: Account.id,
-      });
-
-      // Detach removed policies
-      for (const policyTarget of policyTargets) {
-        const policyTargetName = policyTarget.Name!;
-        if (!accountPolicyNames.includes(policyTargetName) && policyTargetName !== FULL_AWS_ACCESS_POLICY_NAME) {
-          console.log(`Detaching ${policyTargetName} from Account ${accountKey}`);
-          await this.org.detachPolicy(policyTarget.Id!, Account.id);
-        }
-      }
-
-      // Attach new policies
-      for (const accountPolicyName of accountPolicyNames) {
-        const policy = existingPolicies.find(p => p.Name === accountPolicyName);
-        if (!policy) {
-          console.warn(`Cannot find policy with name "${accountPolicyName}"`);
-          continue;
-        }
-
-        const policyTarget = policyTargets.find(x => x.Name === accountPolicyName);
-        if (policyTarget) {
-          console.log(`Skipping attachment of ${accountPolicyName} to already attached Account ${accountKey}`);
-          continue;
-        }
-
-        console.log(`Attaching ${accountPolicyName} to Account ${accountKey}`);
-        await this.org.attachPolicy(policy.Id!, Account.id);
       }
     }
   }


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#691

- not working as expected, SM execution removes account level scp's even when no SCP line item defined.
- please resubmit once fixed.