### PR TITLE
SSM session timeout in config lite deployment.  The config lite was missing the 'logs' and 'monitoring' interface endpoints.

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
@@ -1067,7 +1067,7 @@
           },
           "interface-endpoints": {
             "subnet": "Endpoint",
-            "endpoints": ["ec2", "ec2messages", "ssm", "ssmmessages", "secretsmanager", "cloudformation", "kms"]
+            "endpoints": ["ec2", "ec2messages", "ssm", "ssmmessages", "secretsmanager", "cloudformation", "kms", "logs", "monitoring"]
           },
           "resolvers": {
             "subnet": "Endpoint",


### PR DESCRIPTION
SSM session timeout in config lite deployment.  The config lite was missing the 'logs' and 'monitoring' interface endpoints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
