### PR TITLE
missed cleaning up zone file outputs in mgmt accounts

### DIFF
--- a/reference-artifacts/Custom-Scripts/SEA-uninstall/aws-sea-cleanup.py
+++ b/reference-artifacts/Custom-Scripts/SEA-uninstall/aws-sea-cleanup.py
@@ -90,6 +90,7 @@ def build_stack_data(accounts, regions, admin_role_name, master_account_name):
 def process_delete(all_stacks):
     phases = [        
         "-Phase5",
+        "Phase4-HostedZonesAssc1",
         "-Phase4",
         "Phase3-CentralVpcResolverEndpoints",
         "-Phase3",


### PR DESCRIPTION
This stack also needs removing or old outputs are made available to new deployments in the same set of accounts causing failure on subsequent runs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
