### PR TITLE
(docs) Documentation and sample config file updates for v133 release

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -70,8 +70,8 @@
   - create, rename, modify, apply and remove SCP's
 - What can't I do:
   - modify Accelerator controlled SCP's
-  - add/remove SCP's on top-level OU's (these are Accelerator controlled)
-    - users can change SCP's on non-top-level ou's and accounts as they please
+  - add/remove SCP's on top-level OU's (these are Accelerator controlled) or specific accounts that have Accelerator controlled SCPs
+    - users can change SCP's on non-top-level ou's and non-Accelerator controlled accounts as they please
   - move an AWS account between top-level ou's (i.e. `Sandbox` to `Prod` is a security violation)
     - moving between `Prod/sub-ou-1` to `Prod/sub-ou2` or `Prod/sub-ou2/sub-ou2a/sub-ou2ab` is fully supported
   - create a top-level ou (need to validate, as they require config file entries)
@@ -79,10 +79,11 @@
   - we do not support forward slashes (`/`) in ou names, even though the AWS platform does
 - More details:
   - If you edit an Accelerator controlled SCP through Organizations, we will reset it per what is defined in the Accelerator configuration files.
-  - If you add/remove an SCP from a top-level ou, we will put them back as defined in the Accelerator configuration file.
+  - If you add/remove an SCP from a top-level ou or Accelerator controlled account, we will put them back as defined in the Accelerator configuration file.
   - If you move an account between top-level ou's, we will put it back to its original designated top-level ou.
-  - The Accelerator fully supports nested ou's, customers can create any depth ou structure in AWS Organizations and add/remove/change SCP's _below_ the top-level as they desire or move accounts between these ou's without restriction. Users can create ou's to the full AWS ou structure/depth.
+  - The Accelerator fully supports nested ou's, customers can create any depth ou structure in AWS Organizations and add/remove/change SCP's _below_ the top-level as they desire or move accounts between these ou's without restriction. Users can create ou's to the full AWS ou structure/depth
   - Except for the Quarantine SCP applied to specific accounts, we do not 'control' SCP's below the top level, customers can add/create/customize SCP's
+    - as of v1.3.3 customers can optionally control account level SCP's through the configuration file
 
 ### 1.1.3. How do I make changes to items I defined in the Accelerator configuration file during installation?
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -231,7 +231,7 @@ If deploying to an internal AWS employee account, to successfully install the so
 8. Add an `Email` address to be used for State Machine Status notification
 9. The `GithubBranch` should point to the release you selected
    - if upgrading, change it to point to the desired release
-   - the latest stable branch is currently `release/v1.3.2`, case sensitive
+   - the latest stable branch is currently `release/v1.3.3`, case sensitive
 10. Apply a tag on the stack, Key=`Accelerator`, Value=`PBMM` (case sensitive).
 11. **ENABLE STACK TERMINATION PROTECTION** under `Stack creation options`
 12. The stack typically takes under 5 minutes to deploy.
@@ -330,7 +330,7 @@ Issues in Older Releases:
 - Upgrades to `v1.2.6 and above` from `v1.2.5 and below` - Ensure you apply the config file changes described in the release notes:
   - Cut-paste the new `"replacements": {},` section at the top of the example config file into your config file, as-is
     - Enables customers to leverage the repo provided SCP's without customization, simplifying upgrades, while allowing SCP region customization
-    - the cloud-cidrX/cloud-maskX variables are examples of customer provided values that can be used to consistently auto-replace values throughout config files, these 4 specific variables are required for the firewalls to successfully deploy
+    - the cloud-cidrX/cloud-maskX variables are examples of customer provided values that can be used to consistently auto-replace values throughout config files, these 4 specific variables are ***all*** required for the firewalls to successfully deploy
   - The new ${variable} are auto-replaced across your config files, SCP's and firewall config files.
     - as the variables should resolve to their existing values, you can leave your config file using hardcoded region and Accelerator prefix naming, or you can update them to make subsequent file comparisons easier for future upgrades. These are most useful for new installations in non ca-central-1 regions
   - Some repo provide filenames have changed, where they are referenced within the config file, you must update them to their new filenames

--- a/docs/installation/sm_inputs.md
+++ b/docs/installation/sm_inputs.md
@@ -45,6 +45,26 @@ Providing any one or more of the following flags will only override the specifie
  }
 ```
 
+## 1.4. Generate verbose logging ithin state machine
+
+- Added "verbose": "1" state machine input options
+- parameter is optional
+- parameter defaults to 0
+
+```
+{"scope":"FULL", "mode":"APPLY", "verbose":"1"}
+```
+
+## 1.5. ADDITIONAL MANDATORY STATE MACHINE INPUT FUNCTIONALITY
+
+See [NEW: State Machine Behavior](https://github.com/aws-samples/aws-secure-environment-accelerator/blob/main/docs/installation/customization-index.md#2-new-state-machine-behavior).
+
+- {"scope":"FULL", "mode":"APPLY"}
+- {"scope":"NEW-ACCOUNTS", "mode":"APPLY"}
+- {"scope":"GLOBAL-OPTIONS", "mode":"APPLY"}
+- {"scope":"OU", "targetOUs":[X], "mode":"APPLY"}
+- {"scope":"ACCOUNT", "targetAccounts":[X], "mode":"APPLY"}
+
 ---
 
 [...Return to Accelerator Table of Contents](../index.md)

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -6,7 +6,7 @@
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
     "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
-    "INFO1": "If deploying the firewalls, both cidr values below must be supplied",
+    "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
@@ -1389,7 +1389,7 @@
           "deploy": "local",
           "name": "Perimeter",
           "cidr": "10.7.4.0/22",
-          "cidr2": "100.96.250.0/23",
+          "cidr2": ["100.96.250.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": false,
           "flow-logs": "BOTH",
@@ -1997,7 +1997,7 @@
           "deploy": "shared-network",
           "name": "Central",
           "cidr": "10.1.0.0/16",
-          "cidr2": "100.96.252.0/23",
+          "cidr2": ["100.96.252.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": true,
           "flow-logs": "BOTH",
@@ -2179,17 +2179,17 @@
                 {
                   "az": "a",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.0/25"
+                  "cidr": "100.96.252.0/25"
                 },
                 {
                   "az": "b",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.128/25"
+                  "cidr": "100.96.252.128/25"
                 },
                 {
                   "az": "d",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.253.0/25",
+                  "cidr": "100.96.253.0/25",
                   "disabled": true
                 }
               ]

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -5,12 +5,16 @@
       "b": ["${HOME_REGION}", "${GBL_REGION}"],
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
-    "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
+    "INFO": "Deploying in us-east-1 requires removing ${GBL_REGION} from the above variables",
     "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
-    "cloud-mask2": "255.255.254.0"
+    "cloud-mask2": "255.255.254.0",
+    "range-restrict": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+    "range-mad": "100.96.252.0/23",
+    "range-dev-test": ["0.0.0.0/0"],
+    "alarm-not-ip": "10.10.10.*"
   },
   "global-options": {
     "alz-baseline": false,
@@ -365,7 +369,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "SSOAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -375,7 +379,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "IAMAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -1059,7 +1063,7 @@
           "central-resolver-rule-vpc": "Endpoint",
           "log-group-name": "/${ACCELERATOR_PREFIX_ND}/MAD/example.local",
           "share-to-account": "",
-          "restrict_srcips": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+          "restrict_srcips": "${RANGE-RESTRICT}",
           "num-rdgw-hosts": 1,
           "min-rdgw-hosts": 1,
           "max-rdgw-hosts": 2,
@@ -1104,7 +1108,7 @@
                 {
                   "description": "Allow RDP Traffic Inbound",
                   "type": ["RDP"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1130,7 +1134,7 @@
                   "description": "Allow Traffic Inbound",
                   "tcp-ports": [514],
                   "udp-ports": [514],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1573,7 +1577,7 @@
                 {
                   "description": "TLS Traffic Inbound",
                   "type": ["HTTPS"],
-                  "source": ["0.0.0.0/0"]
+                  "source": "${RANGE-DEV-TEST}"
                 }
               ],
               "outbound-rules": [
@@ -1591,7 +1595,7 @@
                   "description": "Allow Mgmt Traffic Inbound",
                   "tcp-ports": [22, 443, 514, 541, 2032, 3000, 5199, 6020, 6028, 8080],
                   "udp-ports": [9443],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1613,7 +1617,7 @@
                 {
                   "description": "Mgmt Traffic, Customer Outbound traffic and ALBs",
                   "type": ["ALL"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1824,7 +1828,7 @@
           "vpc-name": "ForSSO",
           "subnet": "ForSSO",
           "size": "Small",
-          "restrict_srcips": ["10.249.1.0/24", "100.96.252.0/23"],
+          "restrict_srcips": ["10.249.1.0/24", "${RANGE-MAD}"],
           "connect-account-key": "operations",
           "connect-dir-id": 1001
         }
@@ -2247,7 +2251,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -2736,7 +2740,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3265,7 +3269,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3794,7 +3798,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -4290,7 +4294,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -4771,7 +4775,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -21,7 +21,7 @@
     "ct-baseline": false,
     "default-s3-retention": 90,
     "central-bucket": "AWSDOC-EXAMPLE-BUCKET",
-    "organization-admin-role": "AWSCloudFormationStackSetExecutionRole",
+    "organization-admin-role": "OrganizationAccountAccessRole",
     "default-cwl-retention": 731,
     "workloadaccounts-suffix": 1,
     "workloadaccounts-prefix": "config",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
@@ -5,6 +5,8 @@
       "b": ["${HOME_REGION}", "${GBL_REGION}"],
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
+    "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
+    "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
@@ -1327,7 +1329,7 @@
           "deploy": "local",
           "name": "Perimeter",
           "cidr": "10.7.4.0/22",
-          "cidr2": "100.96.250.0/23",
+          "cidr2": ["100.96.250.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": false,
           "flow-logs": "BOTH",
@@ -1932,7 +1934,7 @@
           "deploy": "shared-network",
           "name": "Central",
           "cidr": "10.1.0.0/16",
-          "cidr2": "100.96.252.0/23",
+          "cidr2": ["100.96.252.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": true,
           "flow-logs": "BOTH",
@@ -2114,17 +2116,17 @@
                 {
                   "az": "a",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.0/25"
+                  "cidr": "100.96.252.0/25"
                 },
                 {
                   "az": "b",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.128/25"
+                  "cidr": "100.96.252.128/25"
                 },
                 {
                   "az": "d",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.253.0/25",
+                  "cidr": "100.96.253.0/25",
                   "disabled": true
                 }
               ]

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
@@ -21,7 +21,7 @@
     "ct-baseline": false,
     "default-s3-retention": 90,
     "central-bucket": "AWSDOC-EXAMPLE-BUCKET",
-    "organization-admin-role": "AWSCloudFormationStackSetExecutionRole",
+    "organization-admin-role": "OrganizationAccountAccessRole",
     "default-cwl-retention": 731,
     "workloadaccounts-suffix": 1,
     "workloadaccounts-prefix": "config",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
@@ -5,12 +5,16 @@
       "b": ["${HOME_REGION}", "${GBL_REGION}"],
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
-    "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
+    "INFO": "Deploying in us-east-1 requires removing ${GBL_REGION} from the above variables",
     "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
-    "cloud-mask2": "255.255.254.0"
+    "cloud-mask2": "255.255.254.0",
+    "range-restrict": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+    "range-mad": "100.96.252.0/23",
+    "range-dev-test": ["0.0.0.0/0"],
+    "alarm-not-ip": "10.10.10.*"
   },
   "global-options": {
     "alz-baseline": false,
@@ -365,7 +369,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "SSOAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -375,7 +379,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "IAMAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -999,7 +1003,7 @@
           "central-resolver-rule-vpc": "Endpoint",
           "log-group-name": "/${ACCELERATOR_PREFIX_ND}/MAD/example.local",
           "share-to-account": "",
-          "restrict_srcips": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+          "restrict_srcips": "${RANGE-RESTRICT}",
           "num-rdgw-hosts": 1,
           "min-rdgw-hosts": 1,
           "max-rdgw-hosts": 2,
@@ -1044,7 +1048,7 @@
                 {
                   "description": "Allow RDP Traffic Inbound",
                   "type": ["RDP"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1070,7 +1074,7 @@
                   "description": "Allow Traffic Inbound",
                   "tcp-ports": [514],
                   "udp-ports": [514],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1513,7 +1517,7 @@
                 {
                   "description": "TLS Traffic Inbound",
                   "type": ["HTTPS"],
-                  "source": ["0.0.0.0/0"]
+                  "source": "${RANGE-DEV-TEST}"
                 }
               ],
               "outbound-rules": [
@@ -1531,7 +1535,7 @@
                   "description": "Allow Mgmt Traffic Inbound",
                   "tcp-ports": [22, 443, 514, 541, 2032, 3000, 5199, 6020, 6028, 8080],
                   "udp-ports": [9443],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1553,7 +1557,7 @@
                 {
                   "description": "Mgmt Traffic, Customer Outbound traffic and ALBs",
                   "type": ["ALL"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1761,7 +1765,7 @@
           "vpc-name": "ForSSO",
           "subnet": "ForSSO",
           "size": "Small",
-          "restrict_srcips": ["10.249.1.0/24", "100.96.252.0/23"],
+          "restrict_srcips": ["10.249.1.0/24", "${RANGE-MAD}"],
           "connect-account-key": "operations",
           "connect-dir-id": 1001
         }
@@ -2184,7 +2188,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -2673,7 +2677,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3202,7 +3206,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3731,7 +3735,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3972,8 +3976,6 @@
             "SAGEMAKER_ENDPOINT_CONFIGURATION_KMS_KEY_CONFIGURED",
             "SAGEMAKER_NOTEBOOK_INSTANCE_KMS_KEY_CONFIGURED",
             "SECURITYHUB_ENABLED",
-            "VPC_DEFAULT_SECURITY_GROUP_CLOSED",
-            "VPC_FLOW_LOGS_ENABLED",
             "VPC_SG_OPEN_ONLY_TO_AUTHORIZED_PORTS",
             "WAFV2_LOGGING_ENABLED"
           ],
@@ -4214,7 +4216,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -6,7 +6,7 @@
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
     "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
-    "INFO1": "If deploying the firewalls, both cidr values below must be supplied",
+    "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
@@ -1598,7 +1598,7 @@
           "deploy": "local",
           "name": "Perimeter",
           "cidr": "10.7.4.0/22",
-          "cidr2": "100.96.250.0/23",
+          "cidr2": ["100.96.250.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": false,
           "flow-logs": "BOTH",
@@ -2488,7 +2488,7 @@
           "deploy": "shared-network",
           "name": "Central",
           "cidr": "10.1.0.0/16",
-          "cidr2": "100.96.252.0/23",
+          "cidr2": ["100.96.252.0/23"],
           "region": "${HOME_REGION}",
           "use-central-endpoints": true,
           "flow-logs": "BOTH",
@@ -2670,17 +2670,17 @@
                 {
                   "az": "a",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.0/25"
+                  "cidr": "100.96.252.0/25"
                 },
                 {
                   "az": "b",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.252.128/25"
+                  "cidr": "100.96.252.128/25"
                 },
                 {
                   "az": "d",
                   "route-table": "CentralVPC_GCWide",
-                  "cidr2": "100.96.253.0/25",
+                  "cidr": "100.96.253.0/25",
                   "disabled": false
                 }
               ]

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -5,12 +5,16 @@
       "b": ["${HOME_REGION}", "${GBL_REGION}"],
       "c": ["${HOME_REGION}", "${GBL_REGION}", "us-east-2", "us-west-1", "us-west-2"]
     },
-    "INFO": "This file will not work in us-east-1 without removing references to GBL_REGION",
+    "INFO": "Deploying in us-east-1 requires removing ${GBL_REGION} from the above variables and replacing us-east-1 with a 2nd region on lines 531,5249, and 5299",
     "INFO1": "If deploying the firewalls, both cidr values below MUST be supplied",
     "cloud-cidr1": "10.0.0.0",
     "cloud-mask1": "255.0.0.0",
     "cloud-cidr2": "100.96.252.0",
-    "cloud-mask2": "255.255.254.0"
+    "cloud-mask2": "255.255.254.0",
+    "range-restrict": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+    "range-mad": "100.96.252.0/23",
+    "range-dev-test": ["0.0.0.0/0"],
+    "alarm-not-ip": "10.10.10.*"
   },
   "global-options": {
     "alz-baseline": false,
@@ -369,7 +373,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "SSOAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -379,7 +383,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "IAMAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -1268,7 +1272,7 @@
           "central-resolver-rule-vpc": "Endpoint",
           "log-group-name": "/${ACCELERATOR_PREFIX_ND}/MAD/example.local",
           "share-to-account": "",
-          "restrict_srcips": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"],
+          "restrict_srcips": "${RANGE-RESTRICT}",
           "num-rdgw-hosts": 1,
           "min-rdgw-hosts": 1,
           "max-rdgw-hosts": 2,
@@ -1313,7 +1317,7 @@
                 {
                   "description": "Allow RDP Traffic Inbound",
                   "type": ["RDP"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1339,7 +1343,7 @@
                   "description": "Allow Traffic Inbound",
                   "tcp-ports": [514],
                   "udp-ports": [514],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1792,7 +1796,7 @@
                 {
                   "description": "TLS Traffic Inbound",
                   "type": ["HTTPS"],
-                  "source": ["0.0.0.0/0"]
+                  "source": "${RANGE-DEV-TEST}"
                 }
               ],
               "outbound-rules": [
@@ -1810,7 +1814,7 @@
                   "description": "Allow Mgmt Traffic Inbound",
                   "tcp-ports": [22, 443, 514, 541, 2032, 3000, 5199, 6020, 6028, 8080],
                   "udp-ports": [9443],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -1832,7 +1836,7 @@
                 {
                   "description": "Mgmt Traffic, Customer Outbound traffic and ALBs",
                   "type": ["ALL"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -2049,7 +2053,7 @@
           "subnet": "ForSSO",
           "azs": ["a", "b"],
           "size": "Small",
-          "restrict_srcips": ["10.249.1.0/24", "100.96.252.0/23"],
+          "restrict_srcips": ["10.249.1.0/24", "${RANGE-MAD}"],
           "connect-account-key": "operations",
           "connect-dir-id": 1001
         }
@@ -2738,7 +2742,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [
@@ -3227,7 +3231,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -3756,7 +3760,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -4285,7 +4289,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -4781,7 +4785,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 },
                 {
                   "description": "Central VPC Traffic Inbound",
@@ -5533,7 +5537,7 @@
                 {
                   "description": "Mgmt RDP/SSH Traffic Inbound",
                   "type": ["RDP", "SSH"],
-                  "source": ["10.0.0.0/8", "100.96.252.0/23", "100.96.250.0/23"]
+                  "source": "${RANGE-RESTRICT}"
                 }
               ],
               "outbound-rules": [

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -21,7 +21,7 @@
     "ct-baseline": false,
     "default-s3-retention": 90,
     "central-bucket": "AWSDOC-EXAMPLE-BUCKET",
-    "organization-admin-role": "AWSCloudFormationStackSetExecutionRole",
+    "organization-admin-role": "OrganizationAccountAccessRole",
     "default-cwl-retention": 731,
     "workloadaccounts-suffix": 1,
     "workloadaccounts-prefix": "config",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
@@ -4,7 +4,8 @@
       "a": ["${HOME_REGION}"],
       "b": ["${HOME_REGION}", "${GBL_REGION}"],
       "c": ["${HOME_REGION}", "${GBL_REGION}"]
-    }
+    },
+    "alarm-not-ip": "10.10.10.*"
   },
   "global-options": {
     "alz-baseline": false,
@@ -337,7 +338,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventSource=sso.amazonaws.com) && ($.eventName=Authenticate) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "SSOAuthUnapprovedIPCount",
           "metric-value": "1"
@@ -347,7 +348,7 @@
           "accounts": ["management"],
           "regions": ["${HOME_REGION}"],
           "loggroup-name": "/${ACCELERATOR_PREFIX_ND}/CloudTrail",
-          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != 10.10.10.*) }",
+          "filter-pattern": "{ ($.eventName=ConsoleLogin) && ($.userIdentity.type=IAMUser) && ($.sourceIPAddress != ${ALARM-NOT-IP}) }",
           "metric-namespace": "CloudTrailMetrics",
           "metric-name": "IAMAuthUnapprovedIPCount",
           "metric-value": "1"

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
@@ -12,7 +12,7 @@
     "ct-baseline": false,
     "default-s3-retention": 90,
     "central-bucket": "AWSDOC-EXAMPLE-BUCKET",
-    "organization-admin-role": "AWSCloudFormationStackSetExecutionRole",
+    "organization-admin-role": "OrganizationAccountAccessRole",
     "default-cwl-retention": 731,
     "workloadaccounts-suffix": 1,
     "workloadaccounts-prefix": "config",

--- a/reference-artifacts/SAMPLE_CONFIGS/sample_snippets.md
+++ b/reference-artifacts/SAMPLE_CONFIGS/sample_snippets.md
@@ -1,11 +1,13 @@
 # AWS Secure Environment Accelerator
 
-## **Config File Sample Snippets (Parameters not in sample config file)**
+## **Config File Sample Snippets (Parameters not in sample config files)**
 ---
+## - Tweak Interface Endpoint security groups
+
 SEA v1.3.3 locked down interface endpoint security groups to 0.0.0.0/0:443 inbound, no outbound-rules
 - Some endpoints may require additional inbound ports
 - these can be specified by adding the following to the config file, for each specific interface endpoint
-- this setting overides the default port 443 used when the endpoint is not specified here
+- this setting overides the default port 443 for the specified endpoint(s) only
 - the below example overides the sg for the logs endpoint and the ssmmessages endpoints on all vpcs with endpoints
 
 In global-options:
@@ -25,7 +27,39 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Creates DNS query logging and associate to the VPC
+## - Create a role with trust policies
+```
+{
+            "role": "Demo-Role",
+            "type": "other",
+            "policies": ["AdministratorAccess"],
+            "boundary-policy": "Default-Boundary-Policy",
+            "source-account": "operations",
+            "source-account-role": "TempAdmin",
+            "trust-policy": "none"
+}
+```
+
+---
+
+## - Manage account level SCPs
+
+- Until v1.3.3, SEA only managed SCPs on the top level OUs, where the ability to manage account level SCPs was added
+- If no account level SCP settings exist, account SCPs remain managed through AWS orgs
+- If an account level SCP setting exists, it enforces the SCPs on the account to be as specified in the config file
+
+```
+    "fun-acct": {
+      "account-name": "TheFunAccount",
+      "email": "myemail+aseaT-funacct@example.com",
+      "src-filename": "config.json",
+      "scps": ["Guardrails-Part-2", "Guardrails-Sandbox"],
+      "ou": "Sandbox"
+    }
+```
+---
+
+## - Creates DNS query logging and associate to the VPC
 
 ```
     "vpc": {
@@ -35,17 +69,22 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Update Central Logging Kinesis stream shard count as accounts are added
+## - Update Central Logging Kinesis stream shard count as accounts are added
 
 ```
     "central-log-services": {
 	  "kinesis-stream-shard-count": 2
     }
 ```
+---
+
+## - CWL retention values
+
+```"default-cwl-retention"``` valid values are one of: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
 
 ---
 
-- Override default CWL retention period (Add to any account)
+## - Override default CWL retention period (Add to any account)
 
 ```
      “cwl-retention”: 180
@@ -53,7 +92,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Valid options for vpc flow logs setting on each VPC
+## - Valid options for vpc flow logs setting on each VPC
 
 ```
 "flow-logs": "S3"  ---> S3, CWL, BOTH, NONE
@@ -61,7 +100,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Macie Frequency Supported Values:
+## - Macie Frequency Supported Values:
 
 ```
       "macie-frequency": "SIX_HOURS" ---> FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS
@@ -69,7 +108,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Control MAD/ADC AZ's:
+## - Control MAD/ADC AZ's:
   - if not specified and more than 2 az's exist, selects the first two defined az's in the subnet
 
 ```
@@ -78,7 +117,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- CWL subscription exclusions example
+## - CWL subscription exclusions example
 
 ```
     "central-log-services": {
@@ -94,14 +133,14 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Add a policy to a role in the account to enable RO access to the Log Archive bucket
+## - Add a policy to a role in the account to enable RO access to the Log Archive bucket
 
 ```
    "ssm-log-archive-read-only-access": true
 ```
 
 ---
-- CloudWatch Metric Filters and Alarms
+## - CloudWatch Metric Filters and Alarms
 
 ```
   "global-options": {
@@ -149,7 +188,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Additional regions for Amazon CloudWatch Central Logging to S3
+## - Additional regions for Amazon CloudWatch Central Logging to S3
 
 ```
     "additional-cwl-regions": {
@@ -161,7 +200,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- SNS Topics - If section not provided we create High,Medium,Low,Ignore SNS topics with out subscribers
+## - SNS Topics - If section not provided we create High,Medium,Low,Ignore SNS topics without subscribers
 
 ```
     "central-log-services": {
@@ -176,7 +215,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Cert REQUEST format (Import shown in sample)
+## - Cert REQUEST format (Import shown in sample)
 
 ```
       "certificates": [
@@ -192,7 +231,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Other Budget "include" fields
+## - Other Budget "include" fields
 
 ```
       "default-budgets": {
@@ -214,7 +253,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Cross Account Role Example
+## - Cross Account Role Example
 
 ```
           {
@@ -230,7 +269,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Very basic workload account example and "per account" exceptions example
+## - Very basic workload account example and "per account" exceptions example
 
 ```
   "workload-account-configs": {
@@ -253,7 +292,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Sample limit increases supported
+## - Sample limit increases supported
 
 ```
       "limits": {
@@ -266,7 +305,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- v1.0.4_to_v1.0.5 upgrade MAD fix - REQUIRED ALL 1.0.4 ORIGINAL INSTALLS
+## - v1.0.4_to_v1.0.5 upgrade MAD fix - REQUIRED ALL 1.0.4 ORIGINAL INSTALLS
 
 ```
       "deployments": {
@@ -278,7 +317,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Sample Complex Security Group
+## - Sample Complex Security Group
 
 ```
           {
@@ -317,7 +356,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Sample Single AZ NATGW
+## - Sample Single AZ NATGW
 
 ```
 "natgw": {
@@ -403,7 +442,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Sample PER AZ NATGW
+## - Sample PER AZ NATGW
 
 ```
 "natgw": {
@@ -500,7 +539,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- TGW Route tables plus Multiple TGWs
+## - TGW Route tables plus Multiple TGWs
 
 ```
         "tgw": [
@@ -600,7 +639,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Creating a VPC Virtual Gateway
+## - Creating a VPC Virtual Gateway
 
 ```
           "vgw": {
@@ -643,7 +682,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Disable a Config rule on a per account basis - add this to either workload or mandatory accounts sections
+## - Disable a Config rule on a per account basis - add this to either workload or mandatory accounts sections
 
 ```
       "aws-config": [
@@ -656,7 +695,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Add SCP on a per account basis - add this to either workload or mandatory accounts sections
+## - Add SCP on a per account basis - add this to either workload or mandatory accounts sections
 
 ```
       "scps": [
@@ -667,7 +706,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Future description
+## - Future description
 
 ```
 {future sample}
@@ -675,7 +714,7 @@ In vpc section, under interface endpoints:
 
 ---
 
-- Future description
+## - Future description
 
 ```
 {future sample}

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -24,6 +24,7 @@
       "Sid": "Tag2",
       "Effect": "Deny",
       "NotAction": [
+        "sts:AssumeRole",
         "iam:PassRole",
         "iam:GetRole",
         "iam:GetRolePolicy",


### PR DESCRIPTION
- update vpc CIDR2 to array in sample configs
- remove CIDR2 from subnets in sample configs
- update sample snippets to include account level SCPs
- update sample snippets to include interface endpoint security group enhancements
- fix assumerole block for SEA created roles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
