### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/reference-artifacts/aws-landing-zone-configuration/templates/aws_baseline/aws-landing-zone-iam-password-policy.template
+++ b/reference-artifacts/aws-landing-zone-configuration/templates/aws_baseline/aws-landing-zone-iam-password-policy.template
@@ -184,7 +184,7 @@ Resources:
       Handler: 'index.handler'
       MemorySize: 128
       Role: !GetAtt 'LambdaRole.Arn'
-      Runtime: 'nodejs10.x'
+      Runtime: 'nodejs14.x'
       Timeout: 60
   LambdaLogGroup:
     Type: 'AWS::Logs::LogGroup'


### PR DESCRIPTION
CloudFormation templates in aws-secure-environment-accelerator have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.