### PR TITLE
fix(core): Peering connection role construct issue

### DIFF
--- a/src/deployments/cdk/src/common/peering-connection.ts
+++ b/src/deployments/cdk/src/common/peering-connection.ts
@@ -73,8 +73,13 @@ export namespace PeeringConnection {
         });
         // Find the PCX output that contains the PCX route's VPC
         const peerVpcOutput = peerVpcOutputs.find(output => {
-          const pcxVpc = output.vpcs.find(vpc => vpc.accountKey === pcxRoute.account && vpc.vpcName === pcxRoute.vpc);
-          return !!pcxVpc;
+          const sourcePcxVpc = output.vpcs.find(
+            vpc => vpc.accountKey === pcxRoute.account && vpc.vpcName === pcxRoute.vpc,
+          );
+          const targetPcxVpc = output.vpcs.find(
+            vpc => vpc.accountKey === accountKey && vpc.vpcName === vpcConfig?.name!,
+          );
+          return !!sourcePcxVpc && !!targetPcxVpc;
         });
         const pcxId = peerVpcOutput?.pcxId;
         if (!pcxId) {

--- a/src/deployments/cdk/src/deployments/firewall/cluster/step-2.ts
+++ b/src/deployments/cdk/src/deployments/firewall/cluster/step-2.ts
@@ -135,7 +135,7 @@ async function createCustomerGateways(props: {
         type: 'ipsec.1',
         transitGatewayId: transitGateway.tgwId,
         customerGatewayId: customerGateway.ref,
-        staticRoutesOnly: firewallCgwRouting === 'static' ? true : false,
+        staticRoutesOnly: firewallCgwRouting === 'static' ? true : undefined,
       });
 
       const options = new VpnTunnelOptions(scope, `VpnTunnelOptions${index}`, {


### PR DESCRIPTION
- Creating only one role per account in default region with all targets in assume policy
- To make it work for existing installs didn't change name formation, it will still have source and target in role name but role belongs to a source with all targets defined in configuration.

#740 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
