### PR TITLE
Feature: Static IP Assignments for Private ENIs for Fortinet Firewall Subnet Attachments

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -40,6 +40,7 @@
     - [1.6.7. Some sample configurations provide NACLs and Security Groups. Is that enough?](#167-some-sample-configurations-provide-nacls-and-security-groups-is-that-enough)
     - [1.6.8. Can I deploy the solution as the account root user?](#168-can-i-deploy-the-solution-as-the-account-root-user)
     - [1.6.9. Is the Organizational Management root account monitored similarly to the other accounts in the organization?](#169-is-the-organizational-management-root-account-monitored-similarly-to-the-other-accounts-in-the-organization)
+    - [1.6.10. Can the Fortinet Firewall deployments use static IP Address assignments?](#1610can-the-fortinet-firewall-deployments-use-static-ip-address-assignments)
 
 ## 1.1. Operational Activities
 
@@ -476,6 +477,85 @@ No, you cannot install as the root user. The root user has no ability to assume 
 ### 1.6.9. Is the Organizational Management root account monitored similarly to the other accounts in the organization?
 
 Yes, all accounts including the Organization Management or root account have the same monitoring and logging services enabled. When supported, AWS security services like GuardDuty, Macie, and Security Hub have their delegated administrator account configured as the "security" account. These tools can be used within each local account (including the Organization Management account) within the organization to gain account level visibility or within the Security account for Organization wide visibility. For more information about monitoring and logging refer to [architecture documentation](../architectures/pbmm/architecture.md#7-logging-and-monitoring).
+
+### 1.6.10. Can the Fortinet Firewall deployments use Static Private IP Address assignments?
+
+Yes, the `"port"` stanza in the configuration file can support a private static IP Address assignment from the subnet and az.
+
+Care must be exercised to assure the assigned IP Address is within the correct subnet and correct Availability zone.  Also consider the Amazon reserved IP Addresses (first three addresses, and the last) within subnets when choosing an IP Address to assign.
+
+Using the `config.example.json` as a reference, static IP Assignments would look like this in the `ports:` stanza of the firewall deployment.
+
+```json
+"ports": [
+  {
+    "name": "Public",
+    "subnet": "Public",
+    "create-eip": true,
+    "create-cgw": true,
+    "private-ips": [
+      {
+        "az": "a",
+        "ip": "100.96.250.4"
+      },
+      {
+        "az": "b",
+        "ip": "100.96.250.132"
+      }
+    ]
+  },
+  {
+    "name": "OnPremise",
+    "subnet": "OnPremise",
+    "create-eip": false,
+    "create-cgw": false,
+    "private-ips": [
+      {
+        "az": "a",
+        "ip": "100.96.250.68"
+      },
+      {
+        "az": "b",
+        "ip": "100.96.250.196"
+      }
+    ]
+  },
+  {
+    "name": "FWMgmt",
+    "subnet": "FWMgmt",
+    "create-eip": false,
+    "create-cgw": false,
+    "private-ips": [
+      {
+        "az": "a",
+        "ip": "100.96.251.36"
+      },
+      {
+        "az": "b",
+        "ip": "100.96.251.164"
+      }
+    ]
+  },
+  {
+    "name": "Proxy",
+    "subnet": "Proxy",
+    "create-eip": false,
+    "create-cgw": false,
+    "private-ips": [
+      {
+        "az": "a",
+        "ip": "100.96.251.68"
+      },
+      {
+        "az": "b",
+        "ip": "100.96.251.196"
+      }
+    ]
+  }
+],
+```
+
+Where `private-ips` are not present for the subnet or availability zone an address will be assigned automatically from available addresses when the firewall instance is created.
 
 ---
 

--- a/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
+++ b/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
@@ -125,6 +125,18 @@ export async function step3(props: FirewallStep3Props) {
   }
 }
 
+function findFirewallPrivateIp(props: { firewallConfig: c.FirewallConfig; subnetName: string; az: string }) {
+  const { firewallConfig, subnetName, az } = props;
+  const subnetPort = firewallConfig.ports.filter(e => e.subnet === subnetName)[0];
+  if (subnetPort.hasOwnProperty('private-ips') && subnetPort['private-ips']) {
+    const azIp = subnetPort['private-ips'].filter(e => e.az === az)[0];
+    if (azIp.hasOwnProperty('ip')) {
+      return azIp.ip;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Create firewall for the given VPC and config in the given scope.
  */
@@ -238,9 +250,11 @@ async function createFirewallCluster(props: {
       });
     }
 
+    const privateIp = findFirewallPrivateIp({ firewallConfig, subnetName: subnet.name, az: subnet.az });
     const networkInterface = instance.addNetworkInterface({
       name: vpnConnection.name,
       subnet,
+      privateStaticIp: privateIp,
       securityGroup,
       eipAllocationId: vpnConnection.eipAllocationId,
       vpnTunnelOptions: vpnConnection.vpnTunnelOptions,

--- a/src/lib/cdk-constructs/src/firewall/instance.ts
+++ b/src/lib/cdk-constructs/src/firewall/instance.ts
@@ -123,11 +123,20 @@ export class FirewallInstance extends cdk.Construct {
     name: string;
     securityGroup: SecurityGroup;
     subnet: Subnet;
+    privateStaticIp?: string;
     eipAllocationId?: string;
     vpnTunnelOptions?: FirewallVpnTunnelOptions;
     additionalReplacements?: { [key: string]: string };
   }): ec2.CfnNetworkInterface {
-    const { name, securityGroup, subnet, eipAllocationId, vpnTunnelOptions, additionalReplacements } = props;
+    const {
+      name,
+      securityGroup,
+      subnet,
+      privateStaticIp,
+      eipAllocationId,
+      vpnTunnelOptions,
+      additionalReplacements,
+    } = props;
     const index = this.networkInterfacesProps.length;
 
     // Create network interface
@@ -135,6 +144,7 @@ export class FirewallInstance extends cdk.Construct {
       groupSet: [securityGroup.id],
       subnetId: subnet.id,
       sourceDestCheck: false,
+      privateIpAddress: privateStaticIp,
     });
     this.networkInterfacesProps.push({
       deviceIndex: `${index}`,

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -464,11 +464,17 @@ export const AdcConfigType = t.interface({
   'connect-dir-id': t.number,
 });
 
+export const FirewallPortConfigPrivateIpType = t.interface({
+  az: t.string,
+  ip: t.string,
+});
+
 export const FirewallPortConfigType = t.interface({
   name: t.string,
   subnet: t.string,
   'create-eip': t.boolean,
   'create-cgw': t.boolean,
+  'private-ips': optional(t.array(FirewallPortConfigPrivateIpType)),
 });
 
 export const FirewallConfigType = t.interface({


### PR DESCRIPTION
Ability to specify `private-ips` within the `ports` section of the firewall configuration.  

Where a private IP is assigned for a subnet and availability zone it will be used in the resulting Network Interface section of the CloudFormation template.  

Where `pritate-ips` is not present allocation will occur as it has historically by automatic assignment during instance launch.

See updates in the FAQ for implementation syntax in the `config.json` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
