### PR TITLE
Allow s3:ListBucket for log archive read only role

### DIFF
--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
@@ -64,6 +64,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
@@ -125,6 +125,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
@@ -103,6 +103,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",

--- a/src/deployments/cdk/src/common/iam-assets.ts
+++ b/src/deployments/cdk/src/common/iam-assets.ts
@@ -184,8 +184,8 @@ export class IamAssets extends cdk.Construct {
 
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
-          actions: ['s3:GetObject'],
-          resources: [logBucket.arnForObjects('*')],
+          actions: ['s3:GetObject', 's3:ListBucket'],
+          resources: [logBucket.bucketArn, logBucket.arnForObjects('*')],
         }),
       );
       new CfnIamPolicyOutput(this, `IamSsmReadOnlyPolicyOutput`, {

--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
@@ -151,7 +151,7 @@ async function updateBucketPolicy(props: HandlerProperties, bucketPolicy: Policy
     Principal: {
       AWS: props.roles,
     },
-    Resource: [`${props.logBucketArn}`,`${props.logBucketArn}/*`],
+    Resource: [`${props.logBucketArn}`, `${props.logBucketArn}/*`],
   };
   const updatedBucketPolicy = await constructPolicy(bucketPolicy, readOnlyStatement, props);
   await putBucketPolicy(props.logBucketName, JSON.stringify(updatedBucketPolicy));
@@ -212,5 +212,5 @@ async function onDelete(event: CloudFormationCustomResourceDeleteEvent) {
 }
 
 function getPropertiesFromEvent(event: CloudFormationCustomResourceEvent) {
-  return (event.ResourceProperties as unknown) as HandlerProperties;
+  return event.ResourceProperties as unknown as HandlerProperties;
 }

--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
@@ -212,5 +212,5 @@ async function onDelete(event: CloudFormationCustomResourceDeleteEvent) {
 }
 
 function getPropertiesFromEvent(event: CloudFormationCustomResourceEvent) {
-  return event.ResourceProperties as unknown as HandlerProperties;
+  return (event.ResourceProperties as unknown) as HandlerProperties;
 }

--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
@@ -147,11 +147,11 @@ async function updateBucketPolicy(props: HandlerProperties, bucketPolicy: Policy
   const readOnlyStatement = {
     Sid: logArchiveReadOnlySid,
     Effect: 'Allow',
-    Action: ['s3:GetObject'],
+    Action: ['s3:GetObject', 's3:ListBucket'],
     Principal: {
       AWS: props.roles,
     },
-    Resource: [`${props.logBucketArn}/*`],
+    Resource: [`${props.logBucketArn}`,`${props.logBucketArn}/*`],
   };
   const updatedBucketPolicy = await constructPolicy(bucketPolicy, readOnlyStatement, props);
   await putBucketPolicy(props.logBucketName, JSON.stringify(updatedBucketPolicy));


### PR DESCRIPTION
Allow s3:ListBucket for log archive read-only role. Fixes #798 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
