### PR TITLE
fix: update SCP to fix issues with CloudFront using the Console

### DIFF
--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
@@ -64,6 +64,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
@@ -125,6 +125,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
@@ -103,6 +103,7 @@
         "route53:*",
         "route53domains:*",
         "s3:GetAccountPublic*",
+        "s3:GetBucketLocation",
         "s3:ListAllMyBuckets",
         "s3:ListBuckets",
         "s3:PutAccountPublic*",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The CloudFront Console fails to apply an Origin Access Identity to a S3 bucket when using the Console as it uses the us-east-1 region for S3 api calls. (Note that it is possible to configure this successfully using IaaC).