### PR TITLE
fixes: #814

### DIFF
--- a/src/lib/custom-resources/cdk-security-hub-accept-invites/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-security-hub-accept-invites/cdk/index.ts
@@ -25,6 +25,7 @@ export class SecurityHubAcceptInvites extends cdk.Construct {
       serviceToken: acceptInvites.functionArn,
       properties: {
         masterAccountId: props.masterAccountId,
+        updateMessage: "update"
       },
     });
   }

--- a/src/lib/custom-resources/cdk-security-hub-accept-invites/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-security-hub-accept-invites/runtime/src/index.ts
@@ -51,6 +51,7 @@ async function onCreate(event: CloudFormationCustomResourceEvent) {
     // Accepting Invitation from Master account
     const ownerInvitation = invitations.find(x => x.AccountId === masterAccountId);
     if (ownerInvitation) {
+      console.log(`Accepting Security Hub invitation`);
       const invitationId = ownerInvitation?.InvitationId!;
       await throttlingBackOff(() =>
         hub

--- a/src/lib/custom-resources/cdk-security-hub-send-invites/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-security-hub-send-invites/cdk/index.ts
@@ -30,6 +30,7 @@ export class SecurityHubSendInvites extends cdk.Construct {
       serviceToken: sendInvite.functionArn,
       properties: {
         memberAccounts: props.memberAccounts,
+        updateMessage: "update"
       },
     });
   }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fix for Security Hub createMembers maxes out at 50 accounts #814. Had to add a dummy new parameter to the accept invite custom resource so that CloudFormation would trigger an update. Without this, the code would not be invoked.