### PR TITLE
feat: enhancements to allow config aggregator to be specified in a mandatory account #769

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -67,7 +67,8 @@
       "config-aggr-excl-regions": [],
       "macie": true,
       "macie-excl-regions": [],
-      "macie-frequency": "FIFTEEN_MINUTES"
+      "macie-frequency": "FIFTEEN_MINUTES",
+      "config-aggr": true,
     },
     "central-operations-services": {
       "account": "operations",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-example.json
@@ -67,7 +67,8 @@
       "config-aggr-excl-regions": [],
       "macie": true,
       "macie-excl-regions": [],
-      "macie-frequency": "FIFTEEN_MINUTES"
+      "macie-frequency": "FIFTEEN_MINUTES",
+      "config-aggr": true,
     },
     "central-operations-services": {
       "account": "operations",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -67,7 +67,8 @@
       "config-aggr-excl-regions": [],
       "macie": true,
       "macie-excl-regions": [],
-      "macie-frequency": "FIFTEEN_MINUTES"
+      "macie-frequency": "FIFTEEN_MINUTES",
+      "config-aggr": true,
     },
     "central-operations-services": {
       "account": "operations",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
@@ -132,7 +132,8 @@
         "us-west-1",
         "us-west-2"
       ],
-      "macie-frequency": "FIFTEEN_MINUTES"
+      "macie-frequency": "FIFTEEN_MINUTES",
+      "config-aggr": true,
     },
     "central-operations-services": {
       "account": "operations",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
@@ -42,7 +42,8 @@
       "config-aggr-excl-regions": [],
       "macie": true,
       "macie-excl-regions": ["${GBL_REGION}"],
-      "macie-frequency": "FIFTEEN_MINUTES"
+      "macie-frequency": "FIFTEEN_MINUTES",
+      "config-aggr": true,
     },
     "central-operations-services": {
       "account": "security",

--- a/src/lib/common-config/src/index.ts
+++ b/src/lib/common-config/src/index.ts
@@ -707,6 +707,7 @@ export const CentralServicesConfigType = t.interface({
   'sns-excl-regions': optional(t.array(t.string)),
   'sns-subscription-emails': fromNullable(t.record(t.string, t.array(t.string)), {}),
   's3-retention': optional(t.number),
+  'config-aggr': fromNullable(t.boolean, false),
 });
 
 export const ScpsConfigType = t.interface({

--- a/src/lib/common/src/aws/organizations.ts
+++ b/src/lib/common/src/aws/organizations.ts
@@ -2,6 +2,7 @@ import aws from './aws-client';
 import * as org from 'aws-sdk/clients/organizations';
 import { throttlingBackOff } from './backoff';
 import { listWithNextToken, listWithNextTokenGenerator } from './next-token';
+import { equalIgnoreCase } from './../util/common';
 
 export interface OrganizationalUnit extends org.OrganizationalUnit {
   Path: string;
@@ -347,6 +348,12 @@ export class Organizations {
         .promise(),
     );
     return response.Account;
+  }
+
+  async getAccountByEmail(email: string): Promise<org.Account | undefined> {
+    const accounts = await this.listAccounts();
+
+    return accounts.find(a => equalIgnoreCase(a.Email!, email));
   }
 
   async getOrganizationalUnitWithPath(ouId: string): Promise<OrganizationalUnit> {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This implementation adds the 'config_agg' attribute to the config file enabling the possibility to configure an AWS Config Aggregator in a different location. To support current implementations, the root account will also be an aggregator.