### PR TITLE
Allow accelerator to manage scps defined in global-options section

### DIFF
--- a/src/core/runtime/src/configuration/load-organizations-config.ts
+++ b/src/core/runtime/src/configuration/load-organizations-config.ts
@@ -388,13 +388,25 @@ async function validateScpsCount(
       Filter: 'SERVICE_CONTROL_POLICY',
       TargetId: ouObject.Id!,
     });
-    const accelScps = ouConfig.scps.map(policyName =>
+    const accelOuScps = ouConfig.scps.map(policyName =>
       ServiceControlPolicy.policyNameToAcceleratorPolicyName({ acceleratorPrefix, policyName }),
     );
+    const configScps = config['global-options'].scps;
+    const accelScps = configScps.map(scp =>
+      ServiceControlPolicy.policyNameToAcceleratorPolicyName({
+        acceleratorPrefix,
+        policyName: scp.name,
+      }),
+    );
     const nonAccelScps = attachedScps.filter(as => !accelScps.includes(as.Name!));
-    if (nonAccelScps.length + accelScps.length > MAX_SCPS_ALLOWED) {
+    if (accelOuScps.length > MAX_SCPS_ALLOWED) {
       errors.push(
-        `Max Allowed SCPs for OU "${oukey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator scps ${accelScps.length} => ${accelScps}`,
+        `Max Allowed SCPs for OU "${oukey}" is ${MAX_SCPS_ALLOWED}, found ${accelOuScps.length} OU SCPs defined in config`,
+      );
+    }
+    if (nonAccelScps.length + accelOuScps.length > MAX_SCPS_ALLOWED) {
+      errors.push(
+        `Max Allowed SCPs for OU "${oukey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator OU scps ${accelOuScps.length} => ${accelOuScps}`,
       );
     }
   }

--- a/src/core/runtime/src/configuration/load-organizations-config.ts
+++ b/src/core/runtime/src/configuration/load-organizations-config.ts
@@ -433,7 +433,7 @@ async function validateScpsCount(
         ServiceControlPolicy.policyNameToAcceleratorPolicyName({ acceleratorPrefix, policyName }),
       ) || [];
     const nonAccelScps = attachedScps.filter(as => !accelScps.includes(as.Name!));
-    if (nonAccelScps.length + accelScps.length > MAX_SCPS_ALLOWED) {
+    if (nonAccelScps.length + accelAccountScps.length > MAX_SCPS_ALLOWED) {
       errors.push(
         `Max Allowed SCPs for Account "${accountKey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator scps ${accelAccountScps.length} => ${accelAccountScps}`,
       );

--- a/src/core/runtime/src/configuration/load-organizations-config.ts
+++ b/src/core/runtime/src/configuration/load-organizations-config.ts
@@ -399,11 +399,6 @@ async function validateScpsCount(
       }),
     );
     const nonAccelScps = attachedScps.filter(as => !accelScps.includes(as.Name!));
-    if (accelOuScps.length > MAX_SCPS_ALLOWED) {
-      errors.push(
-        `Max Allowed SCPs for OU "${oukey}" is ${MAX_SCPS_ALLOWED}, found ${accelOuScps.length} OU SCPs defined in config`,
-      );
-    }
     if (nonAccelScps.length + accelOuScps.length > MAX_SCPS_ALLOWED) {
       errors.push(
         `Max Allowed SCPs for OU "${oukey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator OU scps ${accelOuScps.length} => ${accelOuScps}`,

--- a/src/core/runtime/src/configuration/load-organizations-config.ts
+++ b/src/core/runtime/src/configuration/load-organizations-config.ts
@@ -421,14 +421,21 @@ async function validateScpsCount(
       Filter: 'SERVICE_CONTROL_POLICY',
       TargetId: accountObject.accountId,
     });
-    const accelScps: string[] =
+    const configScps = config['global-options'].scps;
+    const accelScps = configScps.map(scp =>
+      ServiceControlPolicy.policyNameToAcceleratorPolicyName({
+        acceleratorPrefix,
+        policyName: scp.name,
+      }),
+    );
+    const accelAccountScps: string[] =
       accountConfig.scps?.map(policyName =>
         ServiceControlPolicy.policyNameToAcceleratorPolicyName({ acceleratorPrefix, policyName }),
       ) || [];
     const nonAccelScps = attachedScps.filter(as => !accelScps.includes(as.Name!));
     if (nonAccelScps.length + accelScps.length > MAX_SCPS_ALLOWED) {
       errors.push(
-        `Max Allowed SCPs for Account "${accountKey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator scps ${accelScps.length} => ${accelScps}`,
+        `Max Allowed SCPs for Account "${accountKey}" is ${MAX_SCPS_ALLOWED}, found already attached scps count ${nonAccelScps.length} and Accelerator scps ${accelAccountScps.length} => ${accelAccountScps}`,
       );
     }
   }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Currently the config validation checks the number of non-accelerator managed SCP's attached to an OU + the SCPs defined on the OU in the config. If this is greater than 5 then the validation fails. This can cause issues if you wish to change the SCP's on an OU to different accelerator managed policies. This results in the policies needing to be manually detached.

This change  updates the config validation to check if the SCP already attached to an OU is an accelerator managed SCP, i.e. exists in "global-config/scps". If it does it does not count it as one of the 5 SCPs, as it will be removed by the accelerator when the SCPs are updated.
