### PR TITLE
Throw error if SCP doesn't exist

### DIFF
--- a/src/lib/common/src/scp/index.ts
+++ b/src/lib/common/src/scp/index.ts
@@ -277,7 +277,7 @@ export class ServiceControlPolicy {
       for (const ouPolicyName of ouPolicyNames) {
         const policy = existingPolicies.find(p => p.Name === ouPolicyName);
         if (!policy) {
-          console.warn(`Cannot find policy with name "${ouPolicyName}"`);
+          throw new Error(`Cannot find policy with name "${ouPolicyName}"`);
           continue;
         }
 
@@ -347,7 +347,7 @@ export class ServiceControlPolicy {
       for (const accountPolicyName of accountPolicyNames) {
         const policy = existingPolicies.find(p => p.Name === accountPolicyName);
         if (!policy) {
-          console.warn(`Cannot find policy with name "${accountPolicyName}"`);
+          throw new Error(`Cannot find policy with name "${accountPolicyName}"`);
           continue;
         }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Currently if the user specifies an SCP that doesn't exist in *global-options/scps* the accelerator warns but doesn't error. It is an easy mistake for users to make when working with the config files, e.g. a typo. Since these are preventative security controls I believe we should fail as the users could incorrectly assume they are protected after running the deployment.