### PR TITLE
scoped down logging SCP scope and moved flow log protection to net SCP

### DIFF
--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -133,7 +133,6 @@
       "Sid": "LOG",
       "Effect": "Deny",
       "Action": [
-        "ec2:DeleteFlowLogs",
         "logs:DeleteResourcePolicy",
         "logs:DeleteMetricFilter",
         "logs:DeleteSubscriptionFilter",
@@ -145,7 +144,7 @@
         "logs:PutSubscriptionFilter",
         "logs:DeleteLogStream"
       ],
-      "Resource": "*",
+      "Resource": "arn:aws:logs:*:*:log-group:*${ACCELERATOR_PREFIX}*",
       "Condition": {
         "ArnNotLike": {
           "aws:PrincipalARN": ["arn:aws:iam::*:role/${ACCELERATOR_PREFIX}*", "arn:aws:iam::*:role/${ORG_ADMIN_ROLE}"]
@@ -190,6 +189,7 @@
       "Sid": "NET1",
       "Effect": "Deny",
       "Action": [
+        "ec2:DeleteFlowLogs",
         "ec2:DeleteNatGateway",
         "ec2:DeleteTransitGatewayRoute",
         "ec2:DeleteTransitGatewayRouteTable",

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -144,7 +144,7 @@
         "logs:PutSubscriptionFilter",
         "logs:DeleteLogStream"
       ],
-      "Resource": "arn:aws:logs:*:*:log-group:*${ACCELERATOR_PREFIX}*",
+      "Resource": "arn:aws:logs:*:*:log-group:*${ACCELERATOR_NAME}*",
       "Condition": {
         "ArnNotLike": {
           "aws:PrincipalARN": ["arn:aws:iam::*:role/${ACCELERATOR_PREFIX}*", "arn:aws:iam::*:role/${ORG_ADMIN_ROLE}"]


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Customers should be able to create their own log groups and specify the policies for these. The accelerator should be protecting the resources it provisions. This change scopes the SCP policy for logging to only protect the accelerator created logs.

If customers wish to place preventative controls around all logs they can do this in separate custom SCP's.