### PR TITLE
Changed the Fortinet Manager instance-sizes and updated the version number in the docs

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -262,7 +262,7 @@ If deploying to an internal AWS employee account and installing the solution wit
     - Click on the product you want to subscribe, in this case `Fortinet FortiGate (BYOL) Next-Generation Firewall` and `Fortinet FortiManager (BYOL Centralized Security Management` **or** `CloudGuard Network Security for Gateway Load Balancer - BYOL` and `Check Point Security Management (BYOL)`
     - Click on "Continue to Subscribe"
     - Click on "Accept Terms" and wait for subscription to be completed
-    - If you are deploying in any region except ca-central-1 or wish to switch to a different license type, you need the new AMI id's. After successfully subscribing, continue one more step and click the “Continue to Configuration”. When you get the below screen, select your region and version (**Fortinet** `v6.4.6`, **Checkpoint Mgmt** `R81.10-335.883` and **CloudGuard** `R80.40-294.374` recommended at this time). Marketplace will provide the required AMI id. Document the two AMI id's, as you will need to update them in your config.json file below.
+    - If you are deploying in any region except ca-central-1 or wish to switch to a different license type, you need the new AMI id's. After successfully subscribing, continue one more step and click the “Continue to Configuration”. When you get the below screen, select your region and version (**Fortinet** `v6.4.7`, **Checkpoint Mgmt** `R81.10-335.883` and **CloudGuard** `R80.40-294.374` recommended at this time). Marketplace will provide the required AMI id. Document the two AMI id's, as you will need to update them in your config.json file below.
 
 ![New AMI ID](img/new-ami-id.png)
 

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
@@ -1816,9 +1816,9 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "c5.large",
+          "instance-sizes": "m4.large",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.4",
+          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
@@ -1816,9 +1816,8 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "m4.large",
+          "instance-sizes": "c5.xlarge",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -1801,9 +1801,9 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "c5.large",
+          "instance-sizes": "m4.large",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.4",
+          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -1801,9 +1801,8 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "m4.large",
+          "instance-sizes": "c5.xlarge",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
@@ -1762,9 +1762,8 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "m4.large",
+          "instance-sizes": "c5.xlarge",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
@@ -1762,9 +1762,9 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "c5.large",
+          "instance-sizes": "m4.large",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.4",
+          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -1747,9 +1747,8 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "m4.large",
+          "instance-sizes": "c5.xlarge",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -1747,9 +1747,9 @@
         "xxfirewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "c5.large",
+          "instance-sizes": "m4.large",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.4",
+          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -2036,9 +2036,9 @@
         "firewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "c5.large",
+          "instance-sizes": "m4.large",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.4",
+          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -2036,9 +2036,8 @@
         "firewall-manager": {
           "name": "FirewallMgr",
           "image-id": "ami-0a0e17ee05506072e",
-          "instance-sizes": "m4.large",
+          "instance-sizes": "c5.xlarge",
           "block-device-mappings": ["/dev/sda1", "/dev/sdb"],
-          "version": "6.4.7",
           "region": "${HOME_REGION}",
           "vpc": "Perimeter",
           "security-group": "FirewallMgr",


### PR DESCRIPTION
The AMI specified in the sample configuration does not use the right instance-size for Fortinet firewall manager. I updated it along with the version that the AMI uses (6.4.7). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
