### PR TITLE
(feature) Added termination-protection for Firewalls and Firewall Manager

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,7 @@ importers:
   src/lib/cdk-constructs:
     specifiers:
       '@aws-accelerator/custom-resource-cfn-sleep': workspace:*
+      '@aws-accelerator/custom-resource-ec2-disable-api-termination': workspace:*
       '@aws-accelerator/custom-resource-elb-deletion-protection': workspace:*
       '@aws-accelerator/custom-resource-r53-dns-endpoint-ips': workspace:*
       '@aws-accelerator/custom-resource-s3-put-bucket-replication': workspace:*
@@ -520,6 +521,7 @@ importers:
       typescript: 4.2.4
     dependencies:
       '@aws-accelerator/custom-resource-cfn-sleep': link:../custom-resources/cdk-cfn-sleep
+      '@aws-accelerator/custom-resource-ec2-disable-api-termination': link:../custom-resources/cdk-ec2-disable-api-termination
       '@aws-accelerator/custom-resource-elb-deletion-protection': link:../custom-resources/cdk-elb-deletion-protection
       '@aws-accelerator/custom-resource-r53-dns-endpoint-ips': link:../custom-resources/cdk-r53-dns-endpoint-ips
       '@aws-accelerator/custom-resource-s3-put-bucket-replication': link:../custom-resources/cdk-s3-put-bucket-replication
@@ -1148,6 +1150,25 @@ importers:
       '@types/aws-lambda': 8.10.76
       '@types/node': 14.14.31
       esbuild: 0.11.18
+      typescript: 4.2.4
+
+  src/lib/custom-resources/cdk-ec2-disable-api-termination:
+    specifiers:
+      '@aws-cdk/aws-iam': 1.113.0
+      '@aws-cdk/core': 1.113.0
+      '@aws-cdk/custom-resources': 1.113.0
+      '@types/node': 14.14.31
+      eslint: 7.25.0
+      ts-node: 9.1.1
+      typescript: 4.2.4
+    dependencies:
+      '@aws-cdk/aws-iam': 1.113.0
+      '@aws-cdk/core': 1.113.0
+      '@aws-cdk/custom-resources': 1.113.0
+    devDependencies:
+      '@types/node': 14.14.31
+      eslint: 7.25.0
+      ts-node: 9.1.1_typescript@4.2.4
       typescript: 4.2.4
 
   src/lib/custom-resources/cdk-ec2-ebs-default-encryption:

--- a/src/deployments/cdk/src/deployments/firewall/manager/step-1.ts
+++ b/src/deployments/cdk/src/deployments/firewall/manager/step-1.ts
@@ -153,6 +153,7 @@ async function createFirewallManager(props: {
       name: config.name,
       suffixLength: 0,
     }),
+    configName: config.name,
     imageId: config['image-id'],
     instanceType: config['instance-sizes'],
     blockDeviceMappings,

--- a/src/lib/cdk-constructs/package.json
+++ b/src/lib/cdk-constructs/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@aws-accelerator/custom-resource-cfn-sleep": "workspace:*",
     "@aws-accelerator/custom-resource-elb-deletion-protection": "workspace:*",
+    "@aws-accelerator/custom-resource-ec2-disable-api-termination": "workspace:*",
     "@aws-accelerator/custom-resource-r53-dns-endpoint-ips": "workspace:*",
     "@aws-accelerator/custom-resource-s3-put-bucket-replication": "workspace:*",
     "@aws-accelerator/custom-resource-s3-template": "workspace:*",

--- a/src/lib/cdk-constructs/src/firewall/instance.ts
+++ b/src/lib/cdk-constructs/src/firewall/instance.ts
@@ -19,6 +19,7 @@ import { S3Template } from '@aws-accelerator/custom-resource-s3-template';
 import { IInstanceProfile } from '../iam';
 import { Subnet, SecurityGroup } from '../vpc';
 import { CfnSleep } from '@aws-accelerator/custom-resource-cfn-sleep';
+import { EC2DisableApiTermination } from '@aws-accelerator/custom-resource-ec2-disable-api-termination';
 
 export interface FirewallVpnTunnelOptions {
   cgwTunnelInsideAddress1: string;
@@ -123,6 +124,11 @@ export class FirewallInstance extends cdk.Construct {
     if (this.template) {
       this.resource.node.addDependency(this.template);
     }
+
+    new EC2DisableApiTermination(this, `EC2${this.props.name}DisableApiTermination`, {
+      ec2Id: this.resource.ref,
+      ec2Name: this.props.name,
+    });
   }
 
   addNetworkInterface(props: {

--- a/src/lib/cdk-constructs/src/firewall/manager.ts
+++ b/src/lib/cdk-constructs/src/firewall/manager.ts
@@ -15,9 +15,11 @@ import * as cdk from '@aws-cdk/core';
 import * as ec2 from '@aws-cdk/aws-ec2';
 import { SecurityGroup, Subnet } from '../vpc';
 import { CfnSleep } from '@aws-accelerator/custom-resource-cfn-sleep';
+import { EC2DisableApiTermination } from '@aws-accelerator/custom-resource-ec2-disable-api-termination';
 
 export interface FirewallManagerProps {
   name: string;
+  configName: string;
   /**
    * Image ID of firewall.
    */
@@ -46,6 +48,11 @@ export class FirewallManager extends cdk.Construct {
       iamInstanceProfile: props.iamInstanceProfile,
     });
     cdk.Tags.of(this.resource).add('Name', this.props.name);
+
+    new EC2DisableApiTermination(this, `EC2-FWMNG${this.props.configName}DisableApiTermination`, {
+      ec2Id: this.resource.ref,
+      ec2Name: this.props.name,
+    });
   }
 
   addNetworkInterface(props: { securityGroup: SecurityGroup; subnet: Subnet; eipAllocationId?: string }) {

--- a/src/lib/custom-resources/cdk-ec2-disable-api-termination/README.md
+++ b/src/lib/custom-resources/cdk-ec2-disable-api-termination/README.md
@@ -1,0 +1,14 @@
+# EC2 Disable API Termination Protection
+
+This is a custom resource to enable disable-api-termination on EC2 instances using `ec2.modifyInstanceAttribute` API call.
+It will be enabled on creation and disabled before delete. This is to make sure we can disable it before the accelerator
+tries to delete the EC2 instance.
+
+## Usage
+
+    import { EC2DisableApiTermination } from '@aws-accelerator/custom-resource-ec2-disable-api-termination';
+
+    new EC2DisableApiTermination(this, `DisableApiTermination`, {
+      ec2Arn: this.resource.ref,
+      ec2Name: this.props.name,
+    });

--- a/src/lib/custom-resources/cdk-ec2-disable-api-termination/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-ec2-disable-api-termination/cdk/index.ts
@@ -1,0 +1,68 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import * as cdk from '@aws-cdk/core';
+import * as custom from '@aws-cdk/custom-resources';
+import * as iam from '@aws-cdk/aws-iam';
+
+export interface EC2DisableApiTerminationProps {
+  ec2Name: string;
+  ec2Id: string;
+}
+
+/**
+ * Custom resource implementation that Enables Deletion Protection on LoadBalancer.
+ */
+export class EC2DisableApiTermination extends cdk.Construct {
+  private readonly ec2Id: string;
+  private readonly ec2Name: string;
+
+  constructor(scope: cdk.Construct, id: string, props: EC2DisableApiTerminationProps) {
+    super(scope, id);
+    this.ec2Id = props.ec2Id;
+    this.ec2Name = props.ec2Name;
+
+    const physicalResourceId = custom.PhysicalResourceId.of(`${this.ec2Name}-DeletionProtection`);
+
+    const onCreateOrUpdate = this.createDisableApiTerminationDefinition(physicalResourceId, true);
+    new custom.AwsCustomResource(this, 'Resource', {
+      resourceType: 'Custom::EC2DisableApiTermination',
+      onCreate: onCreateOrUpdate,
+      onUpdate: onCreateOrUpdate,
+      onDelete: this.createDisableApiTerminationDefinition(physicalResourceId, false),
+      policy: custom.AwsCustomResourcePolicy.fromStatements([
+        new iam.PolicyStatement({
+          actions: ['ec2:ModifyInstanceAttribute'],
+          resources: ['*'],
+        }),
+      ]),
+    });
+  }
+
+  private createDisableApiTerminationDefinition(
+    physicalResourceId: custom.PhysicalResourceId,
+    disableApiTermination: boolean,
+  ): custom.AwsSdkCall {
+    return {
+      service: 'EC2',
+      action: 'modifyInstanceAttribute',
+      physicalResourceId,
+      parameters: {
+        InstanceId: this.ec2Id,
+        DisableApiTermination: {
+          Value: disableApiTermination,
+        },
+      },
+    };
+  }
+}

--- a/src/lib/custom-resources/cdk-ec2-disable-api-termination/package.json
+++ b/src/lib/custom-resources/cdk-ec2-disable-api-termination/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@aws-accelerator/custom-resource-ec2-disable-api-termination",
+  "version": "0.0.1",
+  "private": true,
+  "main": "cdk/index.ts",
+  "scripts": {
+    "lint:typecheck": "pnpx tsc --noEmit",
+    "lint:eslint": "pnpx eslint '{cdk,lib,src}/**/*.{js,ts}'"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-iam": "1.113.0",
+    "@aws-cdk/core": "1.113.0",
+    "@aws-cdk/custom-resources": "1.113.0"
+  },
+  "devDependencies": {
+    "@types/node": "14.14.31",
+    "eslint": "7.25.0",
+    "ts-node": "9.1.1",
+    "typescript": "4.2.4"
+  },
+  "peerDependencies": {
+    "@aws-cdk/aws-iam": "1.101.0",
+    "@aws-cdk/core": "1.101.0",
+    "@aws-cdk/custom-resources": "1.101.0"
+  }
+}

--- a/src/lib/custom-resources/cdk-ec2-disable-api-termination/tsconfig.json
+++ b/src/lib/custom-resources/cdk-ec2-disable-api-termination/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2019", 
+    "lib": [
+      "es2019"
+    ], 
+    "noImplicitAny": true, 
+    "module": "commonjs", 
+    "strict": true, 
+    "esModuleInterop": true, 
+    "moduleResolution": "node", 
+    "outDir": "dist"
+  }, 
+  "exclude": [
+    "node_modules", 
+    "**/*.spec.ts"
+  ], 
+  "include": [
+    "cdk/**/*"
+  ]
+}


### PR DESCRIPTION
Set the option disable-api-termination on EC2 instances created for firewall and firewall manager using a custom construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
