### PR TITLE
(feat) Added possibility to enforce IMDSv2 on launch configuration for RDGW, rsyslog

### DIFF
--- a/src/deployments/cdk/src/common/ad-users-groups.ts
+++ b/src/deployments/cdk/src/common/ad-users-groups.ts
@@ -125,6 +125,7 @@ export class ADUsersAndGroups extends cdk.Construct {
 
     const launchConfig = new LaunchConfiguration(this, 'RDGWLaunchConfiguration', {
       launchConfigurationName: `${prefix}-RDGWLaunchConfiguration`,
+      metadataOptions: madDeploymentConfig['rdgw-enforce-imdsv2'] ? { httpEndpoint: 'enabled', httpTokens: 'required' } : undefined,
       associatePublicIpAddress: false,
       imageId: latestRdgwAmiId,
       securityGroups: [securityGroup.securityGroups[0].id],

--- a/src/deployments/cdk/src/common/ad-users-groups.ts
+++ b/src/deployments/cdk/src/common/ad-users-groups.ts
@@ -125,7 +125,9 @@ export class ADUsersAndGroups extends cdk.Construct {
 
     const launchConfig = new LaunchConfiguration(this, 'RDGWLaunchConfiguration', {
       launchConfigurationName: `${prefix}-RDGWLaunchConfiguration`,
-      metadataOptions: madDeploymentConfig['rdgw-enforce-imdsv2'] ? { httpEndpoint: 'enabled', httpTokens: 'required' } : undefined,
+      metadataOptions: madDeploymentConfig['rdgw-enforce-imdsv2']
+        ? { httpEndpoint: 'enabled', httpTokens: 'required' }
+        : undefined,
       associatePublicIpAddress: false,
       imageId: latestRdgwAmiId,
       securityGroups: [securityGroup.securityGroups[0].id],

--- a/src/deployments/cdk/src/deployments/rsyslog/step-2.ts
+++ b/src/deployments/cdk/src/deployments/rsyslog/step-2.ts
@@ -225,6 +225,7 @@ export function createAsg(
     minInstanceHosts: rsyslogConfig['min-rsyslog-hosts'],
     maxInstanceHosts: rsyslogConfig['max-rsyslog-hosts'],
     maxInstanceAge: rsyslogConfig['rsyslog-max-instance-age'],
+    enforceImdsv2: rsyslogConfig['rsyslog-enforce-imdsv2'],
   });
 }
 

--- a/src/lib/cdk-constructs/src/autoscaling/launch-configuration.ts
+++ b/src/lib/cdk-constructs/src/autoscaling/launch-configuration.ts
@@ -23,7 +23,7 @@ export type LaunchConfigurationProps = autoscaling.CfnLaunchConfigurationProps;
 interface LaunchConfigurationCustomProps extends LaunchConfigurationProps {
   centralBucketName?: string;
   logGroupName?: string;
-  enforceIMDSv2? : boolean;
+  enforceIMDSv2?: boolean;
 }
 
 /**

--- a/src/lib/cdk-constructs/src/autoscaling/launch-configuration.ts
+++ b/src/lib/cdk-constructs/src/autoscaling/launch-configuration.ts
@@ -23,11 +23,12 @@ export type LaunchConfigurationProps = autoscaling.CfnLaunchConfigurationProps;
 interface LaunchConfigurationCustomProps extends LaunchConfigurationProps {
   centralBucketName?: string;
   logGroupName?: string;
+  enforceIMDSv2? : boolean;
 }
 
 /**
  * Wrapper around CfnLaunchConfiguration. The construct adds a hash to the launch configuration name that is based on
- * the launch configuration properties. The hash makes sure the budget gets replaced correctly by CloudFormation.
+ * the launch configuration properties. The hash makes sure the launch configuration gets replaced correctly by CloudFormation.
  */
 export class LaunchConfiguration extends autoscaling.CfnLaunchConfiguration {
   constructor(scope: cdk.Construct, id: string, props: LaunchConfigurationCustomProps) {

--- a/src/lib/cdk-constructs/src/vpc/asg.ts
+++ b/src/lib/cdk-constructs/src/vpc/asg.ts
@@ -31,6 +31,7 @@ export interface RsysLogAutoScalingGroupProps extends cdk.StackProps {
   minInstanceHosts: number;
   maxInstanceHosts: number;
   maxInstanceAge: number;
+  enforceImdsv2: boolean;
 }
 
 export class RsysLogAutoScalingGroup extends cdk.Construct {
@@ -39,6 +40,7 @@ export class RsysLogAutoScalingGroup extends cdk.Construct {
 
     const launchConfig = new LaunchConfiguration(this, 'RsyslogLaunchConfiguration', {
       launchConfigurationName: `${props.acceleratorPrefix}RsyslogLaunchConfiguration`,
+      metadataOptions: props.enforceImdsv2 ? { httpEndpoint: 'enabled', httpTokens: 'required' } : undefined,
       associatePublicIpAddress: false,
       imageId: props.latestRsyslogAmiId,
       securityGroups: [props.securityGroupId],

--- a/src/lib/config-i18n/src/en.ts
+++ b/src/lib/config-i18n/src/en.ts
@@ -1394,6 +1394,10 @@ translate(c.MadConfigType, {
       title: 'Remote Desktop Gateway EC2 instance type',
       description: 'To manage the MAD the Accelerator deploys an EC2 instance to serve as a Remote Desktop Gateway',
     },
+    'rdgw-enforce-imdsv2': {
+      title: 'Enforce IMDSv2 on the EC instances launched for Remote Desktop Gateway',
+      description: 'If set to true, IMDSv2 will be mandatory on the instances. Default : false',
+    },
     'rdgw-instance-role': {
       title: 'Remote Desktop Gateway instance role',
       description: 'EC2 instance role assumed by the RDGW',
@@ -1518,6 +1522,10 @@ translate(c.RsyslogConfig, {
     'rsyslog-instance-type': {
       title: 'rsyslog Instance type',
       description: 'The EC2 instance type for the rsyslog instances (i.e. t3.large)',
+    },
+    'rsyslog-enforce-imdsv2': {
+      title: 'Enforce IMDSv2 on the EC instances launched for rsyslog',
+      description: 'If set to true, IMDSv2 will be mandatory on the instances. Default : false',
     },
     'rsyslog-instance-role': {
       title: 'Instance role',

--- a/src/lib/config-i18n/src/fr.ts
+++ b/src/lib/config-i18n/src/fr.ts
@@ -1279,6 +1279,10 @@ translate(c.MadConfigType, {
       title: '',
       description: '',
     },
+    'rdgw-enforce-imdsv2': {
+      title: '',
+      description: '',
+    },
     'rdgw-instance-role': {
       title: '',
       description: '',
@@ -1394,6 +1398,10 @@ translate(c.RsyslogConfig, {
       description: '',
     },
     'rsyslog-instance-type': {
+      title: '',
+      description: '',
+    },
+    'rsyslog-enforce-imdsv2': {
       title: '',
       description: '',
     },

--- a/src/lib/config/src/config.v2.ts
+++ b/src/lib/config/src/config.v2.ts
@@ -436,6 +436,7 @@ export const MadConfigType = t.interface({
   restrict_srcips: t.array(t.cidr),
   'rdgw-instance-type': t.nonEmptyString,
   'rdgw-instance-role': t.nonEmptyString,
+  'rdgw-enforce-imdsv2': t.defaulted(t.boolean, false),
   'num-rdgw-hosts': t.number,
   'rdgw-max-instance-age': t.number,
   'min-rdgw-hosts': t.number,
@@ -470,6 +471,7 @@ export const RsyslogConfig = t.interface({
   'ssm-image-id': t.nonEmptyString,
   'rsyslog-instance-type': t.nonEmptyString,
   'rsyslog-instance-role': t.nonEmptyString,
+  'rsyslog-enforce-imdsv2': t.defaulted(t.boolean, false),
   'rsyslog-root-volume-size': t.number,
   'rsyslog-max-instance-age': t.number,
 });


### PR DESCRIPTION
Added new configurations (rdgw-enforce-imdsv2 and rsyslog-enforce-imdsv2) that will force IMDSv2 on the launch configurations. If unspecified, the default value for these configuration is false.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
