### PR TITLE
rename GCWide subnet to App2 subnet for new installs in examples (other doc updates)

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
@@ -1134,7 +1134,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1949,7 +1949,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2271,7 +2271,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2494,13 +2494,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.252.0/25",
                     "pool": "RFC6598a",
@@ -2509,7 +2509,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.252.128/25",
                     "pool": "RFC6598a",
@@ -2518,7 +2518,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.253.0/25",
                     "pool": "RFC6598a",
@@ -2549,7 +2549,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3145,7 +3145,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3172,7 +3172,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3203,7 +3203,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3252,7 +3252,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3741,7 +3741,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3768,7 +3768,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3799,7 +3799,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3848,7 +3848,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4337,7 +4337,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4364,7 +4364,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4395,7 +4395,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4444,7 +4444,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4901,7 +4901,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4928,7 +4928,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4959,7 +4959,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5008,7 +5008,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -1131,7 +1131,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1931,7 +1931,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2251,7 +2251,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2459,13 +2459,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2473,7 +2473,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2481,7 +2481,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2511,7 +2511,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3091,7 +3091,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3118,7 +3118,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3149,7 +3149,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3198,7 +3198,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3671,7 +3671,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3698,7 +3698,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3729,7 +3729,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3778,7 +3778,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4251,7 +4251,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4278,7 +4278,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4309,7 +4309,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4358,7 +4358,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4799,7 +4799,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4826,7 +4826,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4857,7 +4857,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4906,7 +4906,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
@@ -1104,7 +1104,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1830,7 +1830,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2152,7 +2152,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2360,13 +2360,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2374,7 +2374,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2382,7 +2382,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2412,7 +2412,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -2992,7 +2992,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3019,7 +3019,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3050,7 +3050,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3099,7 +3099,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3572,7 +3572,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3599,7 +3599,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3630,7 +3630,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3679,7 +3679,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4152,7 +4152,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4179,7 +4179,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4210,7 +4210,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4259,7 +4259,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
@@ -1092,7 +1092,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -2115,7 +2115,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2435,7 +2435,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2643,13 +2643,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2657,7 +2657,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2665,7 +2665,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2695,7 +2695,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3275,7 +3275,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3302,7 +3302,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3333,7 +3333,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3382,7 +3382,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3855,7 +3855,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3882,7 +3882,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3913,7 +3913,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3962,7 +3962,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4435,7 +4435,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4462,7 +4462,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4493,7 +4493,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4542,7 +4542,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
@@ -1087,7 +1087,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1813,7 +1813,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2133,7 +2133,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2341,13 +2341,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2355,7 +2355,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2363,7 +2363,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2393,7 +2393,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -2973,7 +2973,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3000,7 +3000,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3031,7 +3031,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3080,7 +3080,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3553,7 +3553,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3580,7 +3580,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3611,7 +3611,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3660,7 +3660,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4133,7 +4133,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4160,7 +4160,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4191,7 +4191,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4240,7 +4240,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
@@ -1084,7 +1084,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1895,7 +1895,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2217,7 +2217,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2440,13 +2440,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.252.0/25",
                     "pool": "RFC6598a",
@@ -2455,7 +2455,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.252.128/25",
                     "pool": "RFC6598a",
@@ -2464,7 +2464,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "value": "100.96.253.0/25",
                     "pool": "RFC6598a",
@@ -2495,7 +2495,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3091,7 +3091,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3118,7 +3118,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3149,7 +3149,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3198,7 +3198,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3687,7 +3687,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3714,7 +3714,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3745,7 +3745,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3794,7 +3794,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4283,7 +4283,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4310,7 +4310,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4341,7 +4341,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4390,7 +4390,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -1081,7 +1081,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Enterprise",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1877,7 +1877,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2197,7 +2197,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2405,13 +2405,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2419,7 +2419,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2427,7 +2427,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2457,7 +2457,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3037,7 +3037,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3064,7 +3064,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3095,7 +3095,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3144,7 +3144,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3617,7 +3617,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3644,7 +3644,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3675,7 +3675,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3724,7 +3724,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4197,7 +4197,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4224,7 +4224,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4255,7 +4255,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4304,7 +4304,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -1354,7 +1354,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "azs": ["a", "b"],
           "size": "Enterprise",
           "dns-domain": "example.local",
@@ -2174,7 +2174,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2409,7 +2409,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -2431,7 +2431,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -2471,7 +2471,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -2787,7 +2787,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2995,13 +2995,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -3009,7 +3009,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -3017,7 +3017,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -3047,7 +3047,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -3627,7 +3627,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3654,7 +3654,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3685,7 +3685,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3734,7 +3734,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4207,7 +4207,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4234,7 +4234,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4265,7 +4265,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4314,7 +4314,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4787,7 +4787,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -4814,7 +4814,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4845,7 +4845,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -4894,7 +4894,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5335,7 +5335,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -5362,7 +5362,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5393,7 +5393,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5442,7 +5442,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5690,7 +5690,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -5712,7 +5712,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -5752,7 +5752,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
@@ -1135,7 +1135,7 @@
           "deploy": true,
           "vpc-name": "Central",
           "region": "${HOME_REGION}",
-          "subnet": "GCWide",
+          "subnet": "App2",
           "size": "Standard",
           "dns-domain": "example.local",
           "netbios-domain": "example",
@@ -1806,7 +1806,7 @@
                   "destination": {
                     "account": "shared-network",
                     "vpc": "Central",
-                    "subnet": "GCWide"
+                    "subnet": "App2"
                   },
                   "target": "pcx"
                 }
@@ -2143,7 +2143,7 @@
             "source": "management",
             "source-vpc": "ForSSO",
             "source-subnets": "ForSSO",
-            "local-subnets": "GCWide"
+            "local-subnets": "App2"
           },
           "subnets": [
             {
@@ -2351,13 +2351,13 @@
               ]
             },
             {
-              "name": "GCWide",
+              "name": "App2",
               "share-to-ou-accounts": false,
               "share-to-specific-accounts": ["operations"],
               "definitions": [
                 {
                   "az": "a",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2365,7 +2365,7 @@
                 },
                 {
                   "az": "b",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2373,7 +2373,7 @@
                 },
                 {
                   "az": "d",
-                  "route-table": "${CONFIG::VPC_NAME}VPC_GCWide",
+                  "route-table": "${CONFIG::VPC_NAME}VPC_App2",
                   "cidr": {
                     "pool": "RFC6598a",
                     "size": 25
@@ -2403,7 +2403,7 @@
               ]
             },
             {
-              "name": "${CONFIG::VPC_NAME}VPC_GCWide",
+              "name": "${CONFIG::VPC_NAME}VPC_App2",
               "routes": [
                 {
                   "destination": "0.0.0.0/0",
@@ -2999,7 +2999,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 }
@@ -3026,7 +3026,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3057,7 +3057,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },
@@ -3106,7 +3106,7 @@
                   "source": [
                     {
                       "vpc": "Central",
-                      "subnet": ["Web", "App", "Mgmt", "GCWide"]
+                      "subnet": ["Web", "App", "Mgmt", "App2"]
                     }
                   ]
                 },


### PR DESCRIPTION
rename GCWide subnet to App2 subnet for new installs in examples (other doc updates)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
