### PR TITLE
Fix/issue with CFN stack if the log group already exists for NFW (caused by phase rollback/retry)

### DIFF
--- a/src/deployments/cdk/src/common/nfw.ts
+++ b/src/deployments/cdk/src/common/nfw.ts
@@ -66,12 +66,12 @@ export class Nfw extends Construct {
     const acceleratorPrefixNoDash = props.acceleratorPrefix.slice(0, -1);
     const logGroupName = `/${prefix}/Nfw`;
 
-    const cwFlowGroup = new LogGroup(this, `${this.nfwName}NFWCWLFlowLogging`, {
+    const cwFlowGroup = new LogGroup(this, `${this.nfwName}NFWCWLFlowLogs`, {
       logGroupName: `/${acceleratorPrefixNoDash}/Nfw/${this.nfwName}/Flow`,
       roleArn: props.logGroupRoleArn,
     });
 
-    const cwAlertGroup = new LogGroup(this, `${this.nfwName}NFWCWLAlertLogging`, {
+    const cwAlertGroup = new LogGroup(this, `${this.nfwName}NFWCWLAlertLogs`, {
       logGroupName: `/${acceleratorPrefixNoDash}/Nfw/${this.nfwName}/Alert`,
       roleArn: props.logGroupRoleArn,
     });

--- a/src/deployments/cdk/src/common/nfw.ts
+++ b/src/deployments/cdk/src/common/nfw.ts
@@ -16,6 +16,7 @@ import { Construct, Fn } from '@aws-cdk/core';
 import { AzSubnet } from './vpc';
 import * as defaults from '../deployments/defaults';
 import * as logs from '@aws-cdk/aws-logs';
+import { LogGroup } from '@aws-accelerator/custom-resource-logs-log-group';
 
 export interface NfwProps {
   subnets: AzSubnet[];
@@ -30,6 +31,7 @@ export interface NfwProps {
   nfwFlowLogging: 'S3' | 'CloudWatch' | 'None';
   nfwAlertLogging: 'S3' | 'CloudWatch' | 'None';
   nfwFlowCWLDestination?: string;
+  logGroupRoleArn: string;
   logBucket?: defaults.RegionalBucket;
 }
 
@@ -64,12 +66,14 @@ export class Nfw extends Construct {
     const acceleratorPrefixNoDash = props.acceleratorPrefix.slice(0, -1);
     const logGroupName = `/${prefix}/Nfw`;
 
-    const cwFlowGroup = new logs.LogGroup(this, `${this.nfwName}NFWCWLFlowLogging`, {
+    const cwFlowGroup = new LogGroup(this, `${this.nfwName}NFWCWLFlowLogging`, {
       logGroupName: `/${acceleratorPrefixNoDash}/Nfw/${this.nfwName}/Flow`,
+      roleArn: props.logGroupRoleArn,
     });
 
-    const cwAlertGroup = new logs.LogGroup(this, `${this.nfwName}NFWCWLAlertLogging`, {
+    const cwAlertGroup = new LogGroup(this, `${this.nfwName}NFWCWLAlertLogging`, {
       logGroupName: `/${acceleratorPrefixNoDash}/Nfw/${this.nfwName}/Alert`,
+      roleArn: props.logGroupRoleArn,
     });
 
     if (this.nfwPolicy.statelessRuleGroup) {

--- a/src/deployments/cdk/src/common/vpc.ts
+++ b/src/deployments/cdk/src/common/vpc.ts
@@ -594,6 +594,13 @@ export class Vpc extends cdk.Construct implements constructs.Vpc {
         nfwSubnets.push(...this.azSubnets.getAzSubnetsForSubnetName(subnetConfig.name));
       }
 
+      // Find the role that will create the loggroup for the NFW
+      const logGroupRole = IamRoleOutputFinder.tryFindOneByName({
+        outputs: props.vpcProps.outputs,
+        accountKey,
+        roleKey: 'LogGroupRole',
+      });
+
       this.nfw = new Nfw(this, `${nfwProps['firewall-name']}`, {
         nfwPolicy: nfwProps.policyString,
         nfwPolicyConfig: nfwProps.policy || { name: 'Sample-Firewall-Policy', path: 'nfw/nfw-example-policy.json' },
@@ -603,6 +610,7 @@ export class Vpc extends cdk.Construct implements constructs.Vpc {
         acceleratorPrefix: vpcProps.acceleratorPrefix || '',
         nfwFlowLogging: nfwProps['flow-dest'] || 'None',
         nfwAlertLogging: nfwProps['alert-dest'] || 'None',
+        logGroupRoleArn: logGroupRole?.roleArn ?? '', // Make the state machine fails for the firewall, something is wrong we did not find a loggroup role and we should
         logBucket: vpcProps.logBucket,
       });
     }


### PR DESCRIPTION
Used a custom construct that succeeds when the log group already exists instead of the default construct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
