### PR TITLE
feat: added encryption key for sns topics and encrypt them by default

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export AWS_PROFILE=amribah+asea+dev-Admin

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export AWS_PROFILE=amribah+asea+dev-Admin

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 aws-landing-zone-configuration.zip
 **/dist
 .idea
+.envrc

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -1095,6 +1095,7 @@ export namespace InitialSetup {
       const notificationTopic = new sns.Topic(this, 'MainStateMachineStatusTopic', {
         displayName: `${props.acceleratorPrefix}-MainStateMachine-Status_topic`,
         topicName: `${props.acceleratorPrefix}-MainStateMachine-Status_topic`,
+        masterKey: installerCmk,
       });
 
       new sns.Subscription(this, 'MainStateMachineStatusTopicSubscription', {

--- a/src/deployments/cdk/src/apps/phase-0.ts
+++ b/src/deployments/cdk/src/apps/phase-0.ts
@@ -89,7 +89,7 @@ export async function deploy({
     });
   }
 
-  // Create defaults, e.g. S3 buckets, EBS encryption keys, SNS encryption keys
+  // Create defaults, e.g. S3 buckets, EBS encryption keys
   const defaultsResult = await defaults.step1({
     acceleratorPrefix: context.acceleratorPrefix,
     accountStacks,

--- a/src/deployments/cdk/src/apps/phase-0.ts
+++ b/src/deployments/cdk/src/apps/phase-0.ts
@@ -32,8 +32,6 @@ import { getAccountId } from '../utils/accounts';
 import * as rsyslogDeployment from '../deployments/rsyslog';
 import * as cleanup from '../deployments/cleanup';
 import * as keyPair from '../deployments/key-pair';
-import { StructuredOutput } from '../common/structured-output';
-import { SnsTopicEncryptionKeyOutput, SnsTopicEncryptionKeyOutputType } from '../deployments/sns';
 
 
 /**
@@ -245,7 +243,6 @@ export async function deploy({
   const logArchiveAccountKey = acceleratorConfig['global-options']['central-log-services'].account;
   const logArchiveStack = accountStacks.getOrCreateAccountStack(logArchiveAccountKey);
   const logArchiveBucket = defaultsResult.centralLogBucket;
-  const managementAccountStack = accountStacks.getOrCreateAccountStack(masterAccountKey);
   new cdk.CfnOutput(logArchiveStack, outputKeys.OUTPUT_LOG_ARCHIVE_ACCOUNT_ID, {
     value: logArchiveStack.accountId,
   });
@@ -257,13 +254,6 @@ export async function deploy({
   });
   new cdk.CfnOutput(logArchiveStack, outputKeys.OUTPUT_LOG_ARCHIVE_ENCRYPTION_KEY_ARN, {
     value: logArchiveBucket.encryptionKey!.keyArn,
-  });
-  new StructuredOutput<SnsTopicEncryptionKeyOutput>(managementAccountStack, 'SNSEncryptionKeyOutput', {
-    type: SnsTopicEncryptionKeyOutputType,
-    value: {
-      encryptionKeyId: defaultsResult.snsTopicsEncryptionKey.keyId,
-      encryptionKeyArn: defaultsResult.snsTopicsEncryptionKey.keyArn,
-    },
   });
 
 }

--- a/src/deployments/cdk/src/deployments/defaults/shared.ts
+++ b/src/deployments/cdk/src/deployments/defaults/shared.ts
@@ -78,6 +78,7 @@ export function createDefaultS3Bucket(props: {
         // TODO Isn't there a better way to grant to all AWS services through a condition?
         new iam.ServicePrincipal('ds.amazonaws.com'),
         new iam.ServicePrincipal('delivery.logs.amazonaws.com'),
+        new iam.ServicePrincipal('sns.amazon.com')
       ],
       resources: ['*'],
     }),

--- a/src/deployments/cdk/src/deployments/defaults/shared.ts
+++ b/src/deployments/cdk/src/deployments/defaults/shared.ts
@@ -78,7 +78,7 @@ export function createDefaultS3Bucket(props: {
         // TODO Isn't there a better way to grant to all AWS services through a condition?
         new iam.ServicePrincipal('ds.amazonaws.com'),
         new iam.ServicePrincipal('delivery.logs.amazonaws.com'),
-        new iam.ServicePrincipal('sns.amazon.com')
+        new iam.ServicePrincipal('sns.amazonaws.com')
       ],
       resources: ['*'],
     }),

--- a/src/deployments/cdk/src/deployments/defaults/step-1.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-1.ts
@@ -31,6 +31,7 @@ import { Account } from '../../utils/accounts';
 import { createDefaultS3Bucket, createDefaultS3Key } from './shared';
 import { overrideLogicalId } from '../../utils/cdk';
 import { getVpcSharedAccountKeys } from '../../common/vpc-subnet-sharing';
+import { SNS_ENCRYPTION_KEY_CDK_ID } from '../sns';
 
 export type AccountRegionEbsEncryptionKeys = { [accountKey: string]: { [region: string]: kms.Key } | undefined };
 
@@ -46,6 +47,7 @@ export interface DefaultsStep1Result {
   centralLogBucket: s3.Bucket;
   aesLogBucket?: s3.Bucket;
   accountEbsEncryptionKeys: AccountRegionEbsEncryptionKeys;
+  snsTopicsEncryptionKey: kms.Key
 }
 
 export async function step1(props: DefaultsStep1Props): Promise<DefaultsStep1Result> {
@@ -54,12 +56,14 @@ export async function step1(props: DefaultsStep1Props): Promise<DefaultsStep1Res
   const centralBucketCopy = createCentralBucketCopy(props);
   const centralLogBucket = createCentralLogBucket(props);
   const accountEbsEncryptionKeys = createDefaultEbsEncryptionKey(props);
+  const snsTopicsEncryptionKey = createSnsTopicEncryptionKey(props);
   const aesLogBucket = createAesLogBucket(props);
   return {
     centralBucketCopy,
     centralLogBucket,
     aesLogBucket,
     accountEbsEncryptionKeys,
+    snsTopicsEncryptionKey
   };
 }
 
@@ -483,4 +487,54 @@ function createDefaultEbsEncryptionKey(props: DefaultsStep1Props): AccountRegion
     }
   }
   return accountEbsEncryptionKeys;
+}
+
+function createSnsTopicEncryptionKey(props: DefaultsStep1Props): kms.Key {
+  const { config, accountStacks } = props;
+
+
+  const keyAlias = createEncryptionKeyName('SNS-Key');
+  const mainOrgRegion = config['global-options']['aws-org-management'].region
+  const accountStack = accountStacks.tryGetOrCreateAccountStack(
+    config.getMandatoryAccountKey('master'), mainOrgRegion);
+  const key = new kms.Key(accountStack, SNS_ENCRYPTION_KEY_CDK_ID, {
+    alias: `alias/${keyAlias}`,
+    description: 'Key used to encrypt/decrypt SNS Topics by default',
+    enableKeyRotation: true,
+  });
+
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.AccountPrincipal(cdk.Aws.ACCOUNT_ID)],
+      actions: ['kms:*'],
+      resources: ['*'],
+    }),
+  );
+
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('sns.amazonaws.com')],
+      actions: ['kms:*'],
+      resources: ['*'],
+    }),
+  );
+
+  key.addToResourcePolicy(
+    new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [
+        new iam.ServicePrincipal('cloudwatch.amazonaws.com'),
+        new iam.ServicePrincipal('lambda.amazonaws.com'),
+      ],
+      actions: [
+        'kms:GenerateDataKey',
+        'kms:Decrypt',
+      ],
+      resources: ['*'],
+    }),
+  );
+
+  return key;
 }

--- a/src/deployments/cdk/src/deployments/sns/outputs.ts
+++ b/src/deployments/cdk/src/deployments/sns/outputs.ts
@@ -11,20 +11,7 @@
  *  and limitations under the License.
  */
 
-import * as t from 'io-ts';
 import { createCfnStructuredOutput } from '../../common/structured-output';
 import { SnsTopicOutput } from '@aws-accelerator/common-outputs/src/sns-topic';
 
 export const CfnSnsTopicOutput = createCfnStructuredOutput(SnsTopicOutput);
-
-export const SnsTopicEncryptionKeyOutputType = t.interface(
-  {
-    encryptionKeyId: t.string,
-    encryptionKeyArn: t.string,
-  },
-  'SnsTopicEncryptionKeyOutput',
-);
-
-export type SnsTopicEncryptionKeyOutput = t.TypeOf<typeof SnsTopicEncryptionKeyOutputType>;
-
-export const SNS_ENCRYPTION_KEY_CDK_ID = 'SnsDefaultEncryptionKey';

--- a/src/deployments/cdk/src/deployments/sns/outputs.ts
+++ b/src/deployments/cdk/src/deployments/sns/outputs.ts
@@ -16,3 +16,15 @@ import { createCfnStructuredOutput } from '../../common/structured-output';
 import { SnsTopicOutput } from '@aws-accelerator/common-outputs/src/sns-topic';
 
 export const CfnSnsTopicOutput = createCfnStructuredOutput(SnsTopicOutput);
+
+export const SnsTopicEncryptionKeyOutputType = t.interface(
+  {
+    encryptionKeyId: t.string,
+    encryptionKeyArn: t.string,
+  },
+  'SnsTopicEncryptionKeyOutput',
+);
+
+export type SnsTopicEncryptionKeyOutput = t.TypeOf<typeof SnsTopicEncryptionKeyOutputType>;
+
+export const SNS_ENCRYPTION_KEY_CDK_ID = 'SnsDefaultEncryptionKey';

--- a/src/deployments/cdk/src/deployments/sns/step-1.ts
+++ b/src/deployments/cdk/src/deployments/sns/step-1.ts
@@ -230,7 +230,7 @@ function createSnsTopics(props: {
   });
 
   const encryptionKey = centralServicesRegion !== region ?
-    createKeyWithPolicyForSns(accountStack) :
+    createDefaultKeyWithPolicyForSns(accountStack) :
     retrieveExistingKeyFromCentralRegion(outputs, accountStack);
 
   for (const notificationType of SNS_NOTIFICATION_TYPES) {
@@ -297,7 +297,7 @@ function createSnsTopics(props: {
 }
 
 
-const createKeyWithPolicyForSns = (accountStack: AccountStack) => {
+const createDefaultKeyWithPolicyForSns = (accountStack: AccountStack) => {
   const { encryptionKey } = createDefaultS3Key({
     accountStack,
   });
@@ -338,9 +338,9 @@ const retrieveExistingKeyFromCentralRegion = (outputs: StackOutput[], accountSta
   })
 
   if (!accountBucket?.encryptionKeyArn) {
-    return createKeyWithPolicyForSns(accountStack)
+    return createDefaultKeyWithPolicyForSns(accountStack)
   }
 
-  return kms.Key.fromKeyArn(accountStack, 'DefaultKey', accountBucket?.encryptionKeyArn);
+  return kms.Key.fromKeyArn(accountStack, `${accountStack.accountKey}-DefaultKey`, accountBucket?.encryptionKeyArn);
 }
 

--- a/src/deployments/cdk/src/deployments/sns/step-1.ts
+++ b/src/deployments/cdk/src/deployments/sns/step-1.ts
@@ -295,39 +295,6 @@ function createSnsTopics(props: {
   }
 }
 
-
-const createDefaultKeyWithPolicyForSns = (accountStack: AccountStack) => {
-  const { encryptionKey } = createDefaultS3Key({
-    accountStack,
-  });
-
-  encryptionKey.addToResourcePolicy(new iam.PolicyStatement({
-      sid: 'Allow SNS to use the encryption key',
-      principals: [new iam.ServicePrincipal('sns.amazonaws.com')],
-      actions: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
-      resources: ['*'],
-    }),
-  );
-
-  encryptionKey.addToResourcePolicy(
-    new iam.PolicyStatement({
-      sid: 'Allow Cloudwatch and Lambda to send to the topics with encryption',
-      effect: iam.Effect.ALLOW,
-      principals: [
-        new iam.ServicePrincipal('cloudwatch.amazonaws.com'),
-        new iam.ServicePrincipal('lambda.amazonaws.com'),
-      ],
-      actions: [
-        'kms:GenerateDataKey',
-        'kms:Decrypt',
-      ],
-      resources: ['*'],
-    }),
-  );
-
-  return encryptionKey;
-}
-
 const retrieveExistingKeyFromCentralRegion = (outputs: StackOutput[], accountStack: AccountStack, centralAccount: string) => {
 
   if (accountStack.accountId === centralAccount) {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


In this PR:
- We encrypt the main state machine sns topic with the installercmk
- We create new Bucket Default Keys in regions where the key did not already exist and add sns as a principle to use them
- We ensure that each topic's key comes from the same region
