### PR TITLE
Fix/issue 802 - FW routes

### DIFF
--- a/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
+++ b/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
@@ -344,7 +344,7 @@ async function createFirewallCluster(props: {
     for (const routeTable of routeTables) {
       const routeTableName: string = routeTable.name;
       const routes = routeTable.routes || [];
-      let numberOfRoutesCreated = 0
+      let numberOfRoutesCreated = 0;
       for (const route of routes) {
         if (
           route.target !== 'firewall' ||
@@ -362,7 +362,7 @@ async function createFirewallCluster(props: {
         }
 
         // This is the old way of created the construct name.
-        let constructName = `${firewallName}${routeTableName}_eni_${vpnConnection.name}_${az}`
+        let constructName = `${firewallName}${routeTableName}_eni_${vpnConnection.name}_${az}`;
         // Since we want to continue to support old installation, we only add the suffix for the second routes since
         // they probably don't exist (see https://github.com/aws-samples/aws-secure-environment-accelerator/issues/802)
         // If we fixed the bug for all routes, the stack would fail on first run because it would try to create the
@@ -375,7 +375,7 @@ async function createFirewallCluster(props: {
           destinationCidrBlock: route.destination as string,
           networkInterfaceId: networkInterface.ref,
         });
-        numberOfRoutesCreated++
+        numberOfRoutesCreated++;
       }
     }
   }

--- a/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
+++ b/src/deployments/cdk/src/deployments/firewall/cluster/step-3.ts
@@ -363,7 +363,7 @@ async function createFirewallCluster(props: {
 
         // This is the old way of created the construct name.
         let constructName = `${firewallName}${routeTableName}_eni_${vpnConnection.name}_${az}`;
-        // Since we want to continue to support old installation, we only add the suffix for the second routes since
+        // Since we want to continue to support old installation, we only add the suffix for the second routes and onward since
         // they probably don't exist (see https://github.com/aws-samples/aws-secure-environment-accelerator/issues/802)
         // If we fixed the bug for all routes, the stack would fail on first run because it would try to create the
         // new route without deleting the old one first and it is not possible to have multiple routes with the same destination


### PR DESCRIPTION
I only add the suffix for the second route created so that it does not break current installation. See comment below : 

        // Since we want to continue to support old installation, we only add the suffix for the second routes and onward since
        // they probably don't exist (see https://github.com/aws-samples/aws-secure-environment-accelerator/issues/802)
        // If we fixed the bug for all routes, the stack would fail on first run because it would try to create the
        // new route without deleting the old one first and it is not possible to have multiple routes with the same destination


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
