### PR TITLE
fix/issue 773 - PCX routes

### DIFF
--- a/src/lib/config/src/config.v2.ts
+++ b/src/lib/config/src/config.v2.ts
@@ -139,7 +139,7 @@ export type GatewayEndpointType = t.TypeOf<typeof GatewayEndpointType>;
 export const PcxRouteConfigType = t.interface({
   account: t.nonEmptyString,
   vpc: t.nonEmptyString,
-  subnet: t.nonEmptyString,
+  subnet: t.optional(t.nonEmptyString),
 });
 
 export type PcxRouteConfig = t.TypeOf<typeof PcxRouteConfigType>;


### PR DESCRIPTION
Fixed the issue by using the VPC CIDR range if the subnet is undefined as mentioned in this ticket : https://github.com/aws-samples/aws-secure-environment-accelerator/issues/773

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
