### PR TITLE
Fix/scaling issue bootstrap state machine

### DIFF
--- a/src/core/cdk/cdk.sh
+++ b/src/core/cdk/cdk.sh
@@ -2,10 +2,10 @@
 
 export ACCELERATOR_NAME="ASEA"
 export ACCELERATOR_PREFIX="ASEA-"
-export ACCELERATOR_STATE_MACHINE_NAME=${ACCELERATOR_PREFIX}-MainStateMachine_sm
+export ACCELERATOR_STATE_MACHINE_NAME=${ACCELERATOR_PREFIX}MainStateMachine_sm
 
 export CDK_NEW_BOOTSTRAP=1
-export BOOTSTRAP_STACK_NAME=${ACCELERATOR_PREFIX}-CDKToolkit
+export BOOTSTRAP_STACK_NAME=${ACCELERATOR_PREFIX}CDKToolkit
 # Make sure initial-setup-lambdas and all custom resources are built
 pnpm install --frozen-lockfile
 

--- a/src/core/cdk/package.json
+++ b/src/core/cdk/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "bootstrap": "pnpx cdk bootstrap",
     "deploy": "pnpx cdk deploy",
+    "deploy:noapproval": "pnpx cdk deploy --require-approval never",
     "synth": "pnpx cdk synth",
     "test": "pnpx jest",
     "lint:typecheck": "pnpx tsc --noEmit",

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -813,6 +813,7 @@ export namespace InitialSetup {
       const storeOutputsStateMachine = new sfn.StateMachine(this, `${props.acceleratorPrefix}StoreOutputs_sm`, {
         stateMachineName: `${props.acceleratorPrefix}StoreOutputs_sm`,
         definition: new StoreOutputsTask(this, 'StoreOutputs', {
+          acceleratorPrefix: props.acceleratorPrefix,
           lambdaCode,
           role: pipelineRole,
         }),

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -694,6 +694,7 @@ export namespace InitialSetup {
         {
           stateMachineName: `${props.acceleratorPrefix}StoreOutputsToSsm_sm`,
           definition: new StoreOutputsToSSMTask(this, 'StoreOutputsToSSM', {
+            acceleratorPrefix: props.acceleratorPrefix,
             lambdaCode,
             role: pipelineRole,
           }),

--- a/src/core/cdk/src/tasks/cdk-bootstrap.ts
+++ b/src/core/cdk/src/tasks/cdk-bootstrap.ts
@@ -187,7 +187,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     this.endStates = chain.endStates;
   }
 
-
   private createBootstrapAccountRegionMapperSM(
     lambdaCode: lambda.Code,
     role: iam.IRole,
@@ -195,7 +194,7 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     s3BucketName: string,
     accountBootstrapObjectKey: string,
     assumeRoleName: string,
-    acceleratorPrefix: string
+    acceleratorPrefix: string,
   ) {
     // Tasks that creates the account
     const bootstrapStateMachine = new sfn.StateMachine(this, `${acceleratorPrefix}BootstrapAccount_sm`, {

--- a/src/core/cdk/src/tasks/cdk-bootstrap.ts
+++ b/src/core/cdk/src/tasks/cdk-bootstrap.ts
@@ -158,20 +158,12 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     const bootstrapAccountRegionMapperTask = new tasks.StepFunctionsStartExecution(this, 'Bootstrap Account Region Mapper', {
       stateMachine: this.createBootstrapAccountRegionMapperSM(lambdaCode, role, bootStrapStackName, s3BucketName, accountBootstrapObjectKey, assumeRoleName, acceleratorPrefix, props),
       integrationPattern: sfn.IntegrationPattern.RUN_JOB,
-      // TODO FB verify the input
       input: sfn.TaskInput.fromObject({
         stackName: bootStrapStackName,
-        stackParameters: {
-          'Qualifier.$': '$.acceleratorPrefix',
-        },
-        stackTemplate: {
-          s3BucketName,
-          s3ObjectKey: accountBootstrapObjectKey,
-        },
         'accountId.$': '$.accountId',
-        'region.$': '$.region',
-        ignoreAccountId: cdk.Aws.ACCOUNT_ID,
-        ignoreRegion: cdk.Aws.REGION,
+        'regions.$': '$.regions',
+        'acceleratorPrefix.$': '$.acceleratorPrefix',
+        'operationsAccountId.$': '$.operationsAccountId',
         assumeRoleName,
       }),
       resultPath: 'DISCARD',

--- a/src/core/cdk/src/tasks/cdk-bootstrap.ts
+++ b/src/core/cdk/src/tasks/cdk-bootstrap.ts
@@ -153,20 +153,31 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
       },
     });
 
-
-    const bootstrapAccountRegionMapperTask = new tasks.StepFunctionsStartExecution(this, 'Bootstrap Account Region Mapper', {
-      stateMachine: this.createBootstrapAccountRegionMapperSM(lambdaCode, role, bootStrapStackName, s3BucketName, accountBootstrapObjectKey, assumeRoleName, acceleratorPrefix, props),
-      integrationPattern: sfn.IntegrationPattern.RUN_JOB,
-      input: sfn.TaskInput.fromObject({
-        stackName: bootStrapStackName,
-        'accountId.$': '$.accountId',
-        'regions.$': '$.regions',
-        'acceleratorPrefix.$': '$.acceleratorPrefix',
-      }),
-      resultPath: 'DISCARD',
-    });
+    const bootstrapAccountRegionMapperTask = new tasks.StepFunctionsStartExecution(
+      this,
+      'Bootstrap Account Region Mapper',
+      {
+        stateMachine: this.createBootstrapAccountRegionMapperSM(
+          lambdaCode,
+          role,
+          bootStrapStackName,
+          s3BucketName,
+          accountBootstrapObjectKey,
+          assumeRoleName,
+          acceleratorPrefix,
+          props,
+        ),
+        integrationPattern: sfn.IntegrationPattern.RUN_JOB,
+        input: sfn.TaskInput.fromObject({
+          stackName: bootStrapStackName,
+          'accountId.$': '$.accountId',
+          'regions.$': '$.regions',
+          'acceleratorPrefix.$': '$.acceleratorPrefix',
+        }),
+        resultPath: 'DISCARD',
+      },
+    );
     createBootstrapInAccount.iterator(bootstrapAccountRegionMapperTask);
-
 
     const chain = sfn.Chain.start(getAccountInfoTask)
       .next(createRootBootstrapInRegion)
@@ -177,7 +188,16 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     this.endStates = chain.endStates;
   }
 
-  private createBootstrapAccountRegionMapperSM(lambdaCode: lambda.Code, role: iam.IRole, bootStrapStackName: string, s3BucketName: string, accountBootstrapObjectKey: string, assumeRoleName: string, acceleratorPrefix: string, props: CDKBootstrapTask.Props) {
+  private createBootstrapAccountRegionMapperSM(
+    lambdaCode: lambda.Code,
+    role: iam.IRole,
+    bootStrapStackName: string,
+    s3BucketName: string,
+    accountBootstrapObjectKey: string,
+    assumeRoleName: string,
+    acceleratorPrefix: string,
+    props: CDKBootstrapTask.Props,
+  ) {
     // Tasks that creates the account
     const bootstrapStateMachine = new sfn.StateMachine(this, `${acceleratorPrefix}BootstrapAccount_sm`, {
       stateMachineName: `${props.acceleratorPrefix}BootstrapAccount_sm`,
@@ -187,7 +207,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
         suffix: 'Account Bootstrap Stack',
       }),
     });
-
 
     // State machine that creates the account using the task
     const bootstrapTask = new tasks.StepFunctionsStartExecution(this, 'Bootstrap Acccount', {

--- a/src/core/cdk/src/tasks/cdk-bootstrap.ts
+++ b/src/core/cdk/src/tasks/cdk-bootstrap.ts
@@ -165,7 +165,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
           accountBootstrapObjectKey,
           assumeRoleName,
           acceleratorPrefix,
-          props,
         ),
         integrationPattern: sfn.IntegrationPattern.RUN_JOB,
         input: sfn.TaskInput.fromObject({
@@ -188,6 +187,7 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     this.endStates = chain.endStates;
   }
 
+
   private createBootstrapAccountRegionMapperSM(
     lambdaCode: lambda.Code,
     role: iam.IRole,
@@ -195,12 +195,11 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
     s3BucketName: string,
     accountBootstrapObjectKey: string,
     assumeRoleName: string,
-    acceleratorPrefix: string,
-    props: CDKBootstrapTask.Props,
+    acceleratorPrefix: string
   ) {
     // Tasks that creates the account
     const bootstrapStateMachine = new sfn.StateMachine(this, `${acceleratorPrefix}BootstrapAccount_sm`, {
-      stateMachineName: `${props.acceleratorPrefix}BootstrapAccount_sm`,
+      stateMachineName: `${acceleratorPrefix}BootstrapAccount_sm`,
       definition: new CreateStackTask(this, 'Bootstrap Acccount Task', {
         lambdaCode,
         role,
@@ -245,7 +244,7 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
 
     // In its own state machine
     return new sfn.StateMachine(this, `${acceleratorPrefix}BootstrapAccountRegionMapper_sm`, {
-      stateMachineName: `${props.acceleratorPrefix}BootstrapAccountRegionMapper_sm`,
+      stateMachineName: `${acceleratorPrefix}BootstrapAccountRegionMapper_sm`,
       definition: sfn.Chain.start(createBootstrapInRegion),
     });
   }

--- a/src/core/cdk/src/tasks/cdk-bootstrap.ts
+++ b/src/core/cdk/src/tasks/cdk-bootstrap.ts
@@ -150,7 +150,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
         acceleratorPrefix: acceleratorPrefix.endsWith('-')
           ? acceleratorPrefix.slice(0, -1).toLowerCase()
           : acceleratorPrefix.toLowerCase(),
-        'operationsAccountId.$': '$.operationsAccount.id',
       },
     });
 
@@ -163,8 +162,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
         'accountId.$': '$.accountId',
         'regions.$': '$.regions',
         'acceleratorPrefix.$': '$.acceleratorPrefix',
-        'operationsAccountId.$': '$.operationsAccountId',
-        assumeRoleName,
       }),
       resultPath: 'DISCARD',
     });
@@ -223,7 +220,6 @@ export class CDKBootstrapTask extends sfn.StateMachineFragment {
         'accountId.$': '$.accountId',
         'region.$': '$$.Map.Item.Value',
         'acceleratorPrefix.$': '$.acceleratorPrefix',
-        'operationsAccountId.$': '$.operationsAccountId',
       },
     });
     createBootstrapInRegion.iterator(bootstrapTask);

--- a/src/core/cdk/src/tasks/store-outputs-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-task.ts
@@ -47,7 +47,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 10,
+      maxConcurrency: 50,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',
@@ -120,7 +120,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     const storeAccountRegionOutputs = new sfn.Map(this, `Store Account Region Outputs`, {
       itemsPath: `$.regions`,
       resultPath: 'DISCARD',
-      maxConcurrency: 10,
+      maxConcurrency: 20,
       parameters: {
         'account.$': '$.account',
         'region.$': '$$.Map.Item.Value',

--- a/src/core/cdk/src/tasks/store-outputs-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-task.ts
@@ -37,7 +37,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
   constructor(scope: cdk.Construct, id: string, props: StoreOutputsTask.Props) {
     super(scope, id);
 
-    const { role, lambdaCode, acceleratorPrefix, functionPayload} = props;
+    const { role, lambdaCode, acceleratorPrefix, functionPayload } = props;
 
     role.addToPrincipalPolicy(
       new iam.PolicyStatement({
@@ -78,13 +78,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
       this,
       'Store Outputs Region Mapper',
       {
-        stateMachine: this.createStoreOututsRegionMapperSM(
-          lambdaCode,
-          role,
-          functionPayload,
-          scope,
-          acceleratorPrefix
-        ),
+        stateMachine: this.createStoreOututsRegionMapperSM(lambdaCode, role, functionPayload, scope, acceleratorPrefix),
         integrationPattern: sfn.IntegrationPattern.RUN_JOB,
         input: sfn.TaskInput.fromObject({
           'account.$': '$.account',
@@ -112,7 +106,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     role: IRole,
     functionPayload: { [p: string]: unknown } | undefined,
     scope: Construct,
-    acceleratorPrefix: string
+    acceleratorPrefix: string,
   ) {
     // Task that store the outputs
     const storeOutputsTask = new CodeTask(scope, `Store Outputs`, {

--- a/src/core/cdk/src/tasks/store-outputs-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-task.ts
@@ -12,11 +12,8 @@
  */
 
 import * as cdk from '@aws-cdk/core';
-import { Construct } from '@aws-cdk/core';
 import * as iam from '@aws-cdk/aws-iam';
-import { IRole } from '@aws-cdk/aws-iam';
 import * as lambda from '@aws-cdk/aws-lambda';
-import { Code } from '@aws-cdk/aws-lambda';
 import * as sfn from '@aws-cdk/aws-stepfunctions';
 import { CodeTask } from '@aws-accelerator/cdk-accelerator/src/stepfunction-tasks';
 import * as tasks from '@aws-cdk/aws-stepfunctions-tasks';
@@ -102,10 +99,10 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
   }
 
   private createStoreOututsRegionMapperSM(
-    lambdaCode: Code,
-    role: IRole,
+    lambdaCode: lambda.Code,
+    role: iam.IRole,
     functionPayload: { [p: string]: unknown } | undefined,
-    scope: Construct,
+    scope: cdk.Construct,
     acceleratorPrefix: string,
   ) {
     // Task that store the outputs

--- a/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
@@ -59,7 +59,7 @@ export class StoreOutputsToSSMTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs To SSM`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 10,
+      maxConcurrency: 50,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',
@@ -148,7 +148,7 @@ export class StoreOutputsToSSMTask extends sfn.StateMachineFragment {
     const storeAccountRegionOutputs = new sfn.Map(this, `Store Account Region Outputs To SSM`, {
       itemsPath: `$.regions`,
       resultPath: 'DISCARD',
-      maxConcurrency: 10,
+      maxConcurrency: 20,
       parameters: {
         'account.$': '$.account',
         'region.$': '$$.Map.Item.Value',

--- a/src/core/runtime/src/create-config-recorder/create.ts
+++ b/src/core/runtime/src/create-config-recorder/create.ts
@@ -175,7 +175,6 @@ export const handler = async (input: ConfigServiceInput): Promise<string[]> => {
             errors.push(`${accountId}:${region}: ${error.code}: ${error.message}`);
           }
         }
-
       }
       const createChannel = await createDeliveryChannel(
         configService,

--- a/src/core/runtime/src/create-config-recorder/create.ts
+++ b/src/core/runtime/src/create-config-recorder/create.ts
@@ -122,11 +122,6 @@ export const handler = async (input: ConfigServiceInput): Promise<string[]> => {
     return errors;
   }
 
-  const masterAccountConfig = acceleratorConfig.getAccountByKey(masterAccountKey);
-  const masterAccount = await organizations.getAccountByEmail(masterAccountConfig.email);
-
-  console.log(`Got Master AccountId: ${masterAccount?.Id}`);
-
   const ctSupportedRegions = acceleratorConfig['global-options']['control-tower-supported-regions'];
   const credentials = await sts.getCredentialsForAccountAndRole(
     accountId,
@@ -180,6 +175,7 @@ export const handler = async (input: ConfigServiceInput): Promise<string[]> => {
             errors.push(`${accountId}:${region}: ${error.code}: ${error.message}`);
           }
         }
+
       }
       const createChannel = await createDeliveryChannel(
         configService,

--- a/src/deployments/cdk/src/deployments/ou-validation-events/create-account.ts
+++ b/src/deployments/cdk/src/deployments/ou-validation-events/create-account.ts
@@ -102,6 +102,7 @@ export async function createAccount(input: CreateAccountProps) {
     .when(sfn.Condition.booleanEquals('$.acceleratorInvocation', true), accleratorInvocation)
     .otherwise(verifyCreateAccountTask);
 
+
   const createStateMachine = new sfn.StateMachine(scope, 'StateMachine', {
     stateMachineName: createName({
       name: 'CreateAccountEventTrigger_sm',

--- a/src/deployments/cdk/src/deployments/ou-validation-events/create-account.ts
+++ b/src/deployments/cdk/src/deployments/ou-validation-events/create-account.ts
@@ -102,7 +102,6 @@ export async function createAccount(input: CreateAccountProps) {
     .when(sfn.Condition.booleanEquals('$.acceleratorInvocation', true), accleratorInvocation)
     .otherwise(verifyCreateAccountTask);
 
-
   const createStateMachine = new sfn.StateMachine(scope, 'StateMachine', {
     stateMachineName: createName({
       name: 'CreateAccountEventTrigger_sm',


### PR DESCRIPTION
Fixed an issue with the Bootstrap State Machine where it could reach 25000 history entries (https://docs.aws.amazon.com/step-functions/latest/dg/bp-history-limit.html) and fail when there are multiple regions and multiple accounts created.

As suggested in the AWS documentation above, I've added a new step machine responsible for the mapping of regions and accounts that is invoked in the Bootstrap State Machine. This reduces considerably the number of history entries created. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
