### PR TITLE
fix for 875 additional ConfigRecordRole Access Denied

### DIFF
--- a/src/deployments/cdk/src/apps/phase-0.ts
+++ b/src/deployments/cdk/src/apps/phase-0.ts
@@ -124,6 +124,7 @@ export async function deploy({
     acceleratorPrefix: context.acceleratorPrefix,
     config: acceleratorConfig,
     accountStacks,
+    outputs
   });
 
   // Create MAD secrets

--- a/src/deployments/cdk/src/deployments/defaults/step-1.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-1.ts
@@ -241,6 +241,27 @@ function createCentralLogBucket(props: DefaultsStep1Props) {
     }),
   );
 
+  // Allow Kinesis access bucket
+  logBucket.addToResourcePolicy(
+    new iam.PolicyStatement({
+      principals: anyAccountPrincipal,
+      actions: [
+        's3:GetBucketAcl',
+        's3:PutObject',
+        's3:PutObjectAcl',
+      ],
+      resources: [logBucket.bucketArn, `${logBucket.bucketArn}/*`],
+      conditions: {
+        StringEquals: {
+          'aws:PrincipalOrgID': organizations.organizationId,
+        },
+        ArnLike: {
+          'aws:PrincipalARN': `arn:aws:iam::*:role/${props.acceleratorPrefix}ConfigRecorderRole-*`,
+        },
+      },
+    }),
+  );
+
   logBucket.addToResourcePolicy(
     new iam.PolicyStatement({
       principals: [

--- a/src/deployments/cdk/src/deployments/iam/step-1.ts
+++ b/src/deployments/cdk/src/deployments/iam/step-1.ts
@@ -89,7 +89,7 @@ export async function createConfigServiceRoles(props: IamConfigServiceRoleProps)
      */
     configRecorderRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
-        actions: ['s3:PutObject'],
+        actions: ['s3:PutObject*', 's3:GetBucketAcl'],
         resources: ['*'],
       }),
     );


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This fix updates the ASEA-ConfigRecordRole and log bucket resource policy to resolve access denied CloudTrail entries.
