### PR TITLE
Fix error message when scope="OU"

### DIFF
--- a/src/lib/common-config/src/compare/main.ts
+++ b/src/lib/common-config/src/compare/main.ts
@@ -279,7 +279,7 @@ function scopeValidation(
         );
       }
     } else {
-      throw new Error('"loadOus" is mandatory if scope="OU"');
+      throw new Error('"targetOus" is mandatory if scope="OU"');
     }
   };
   if (scope === 'NEW-ACCOUNTS') {


### PR DESCRIPTION
As far as I can tell `loadOus` is supposed to be `targetOus` in this error message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
