### PR TITLE
feat: early config validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 aws-landing-zone-configuration.zip
 **/dist
 .idea
+.envrc

--- a/src/core/runtime/src/compare-configurations-step.ts
+++ b/src/core/runtime/src/compare-configurations-step.ts
@@ -134,13 +134,7 @@ export const handler = async (input: StepInput) => {
   const { scope, targetAccounts, targetOus } = inputConfig;
 
   const accounts = await loadAccounts(parametersTableName, dynamodb);
-  const accountEmails = accounts.map(account => account.email);
-  console.log(accountEmails);
-  const emailDuplicatesFiltered = [...new Set(accountEmails)];
-  console.log(emailDuplicatesFiltered);
-  if (emailDuplicatesFiltered.length !== accounts.length) {
-    errors.push(`Account email duplicates found.`);
-  }
+
   const targetAccountKeys: string[] = [];
   if (targetAccounts) {
     targetAccounts.map(targetAccount => {

--- a/src/core/runtime/src/compare-configurations-step.ts
+++ b/src/core/runtime/src/compare-configurations-step.ts
@@ -159,23 +159,20 @@ export const handler = async (input: StepInput) => {
     // Limiting query outputs from DDB only for validating cidr changes
     outputs.push(...(await loadOutputs(outputTableName, dynamodb)));
   }
-  errors = [
-    ...errors,
-    ...(await compareAcceleratorConfig({
-      repositoryName: configRepositoryName,
-      configFilePath,
-      commitId: configCommitId,
-      previousCommitId,
-      region,
-      overrideConfig,
-      scope: scope || 'NEW-ACCOUNTS',
-      targetAccounts: targetAccountKeys,
-      targetOus,
-      vpcCidrPoolAssignedTable,
-      subnetCidrPoolAssignedTable,
-      outputs,
-    })),
-  ];
+  errors = await compareAcceleratorConfig({
+    repositoryName: configRepositoryName,
+    configFilePath,
+    commitId: configCommitId,
+    previousCommitId,
+    region,
+    overrideConfig,
+    scope: scope || 'NEW-ACCOUNTS',
+    targetAccounts: targetAccountKeys,
+    targetOus,
+    vpcCidrPoolAssignedTable,
+    subnetCidrPoolAssignedTable,
+    outputs,
+  });
 
   // Throw all errors at once
   if (errors.length > 0) {

--- a/src/core/runtime/src/compare-configurations-step.ts
+++ b/src/core/runtime/src/compare-configurations-step.ts
@@ -159,20 +159,23 @@ export const handler = async (input: StepInput) => {
     // Limiting query outputs from DDB only for validating cidr changes
     outputs.push(...(await loadOutputs(outputTableName, dynamodb)));
   }
-  errors = await compareAcceleratorConfig({
-    repositoryName: configRepositoryName,
-    configFilePath,
-    commitId: configCommitId,
-    previousCommitId,
-    region,
-    overrideConfig,
-    scope: scope || 'NEW-ACCOUNTS',
-    targetAccounts: targetAccountKeys,
-    targetOus,
-    vpcCidrPoolAssignedTable,
-    subnetCidrPoolAssignedTable,
-    outputs,
-  });
+  errors = [
+    ...errors,
+    ...(await compareAcceleratorConfig({
+      repositoryName: configRepositoryName,
+      configFilePath,
+      commitId: configCommitId,
+      previousCommitId,
+      region,
+      overrideConfig,
+      scope: scope || 'NEW-ACCOUNTS',
+      targetAccounts: targetAccountKeys,
+      targetOus,
+      vpcCidrPoolAssignedTable,
+      subnetCidrPoolAssignedTable,
+      outputs,
+    })),
+  ];
 
   // Throw all errors at once
   if (errors.length > 0) {

--- a/src/core/runtime/src/compare-configurations-step.ts
+++ b/src/core/runtime/src/compare-configurations-step.ts
@@ -133,6 +133,12 @@ export const handler = async (input: StepInput) => {
   const { scope, targetAccounts, targetOus } = inputConfig;
 
   const accounts = await loadAccounts(parametersTableName, dynamodb);
+  const accountEmails = accounts.map(account => account.email);
+  const emailDuplicatesFiltered = [...new Set(accountEmails)];
+
+  if (emailDuplicatesFiltered.length !== accounts.length) {
+    errors.push(`Account email duplicates found.`);
+  }
   const targetAccountKeys: string[] = [];
   if (targetAccounts) {
     targetAccounts.map(targetAccount => {

--- a/src/core/runtime/src/compare-configurations-step.ts
+++ b/src/core/runtime/src/compare-configurations-step.ts
@@ -18,6 +18,7 @@ import { DynamoDB } from '@aws-accelerator/common/src/aws/dynamodb';
 import { loadAccounts } from './utils/load-accounts';
 import { loadOutputs } from './utils/load-outputs';
 import { StackOutput } from '@aws-accelerator/common-outputs/src/stack-output';
+import * as console from 'console';
 
 export interface StepInput extends ConfigurationInput {
   inputConfig: AcceleratorInput;
@@ -134,8 +135,9 @@ export const handler = async (input: StepInput) => {
 
   const accounts = await loadAccounts(parametersTableName, dynamodb);
   const accountEmails = accounts.map(account => account.email);
+  console.log(accountEmails);
   const emailDuplicatesFiltered = [...new Set(accountEmails)];
-
+  console.log(emailDuplicatesFiltered);
   if (emailDuplicatesFiltered.length !== accounts.length) {
     errors.push(`Account email duplicates found.`);
   }

--- a/src/lib/common-config/src/compare/main.ts
+++ b/src/lib/common-config/src/compare/main.ts
@@ -88,7 +88,7 @@ export async function compareAcceleratorConfig(props: {
   // Check for duplicate email entry
   const acceleratorConfig = AcceleratorConfig.fromObject(modifiedConfig);
   checkForEmailDuplicates(acceleratorConfig, errors);
-  checkForMismatchedAccountKeys(modifiedConfig, errors);
+  checkForMismatchedAccountKeys(acceleratorConfig, errors);
 
   scopeValidation(scope, configChanges, errors, targetAccounts || [], targetOus || []);
 
@@ -197,16 +197,23 @@ function checkForEmailDuplicates(acceleratorConfig: AcceleratorConfig, errors: s
   }
 }
 
-function checkForMismatchedAccountKeys(modifiedConfig: any, errors: string[]) {
+function checkForMismatchedAccountKeys(acceleratorConfig: AcceleratorConfig, errors: string[]) {
   const mandatoryAccountKeys = [
     'aws-org-management',
     'central-security-services',
     'central-operations-services',
     'central-log-services',
   ];
-  const globalAccountKeys = mandatoryAccountKeys.map(key => modifiedConfig['global-options'][key].account);
+  // @ts-ignore
+  const globalAccountKeys = mandatoryAccountKeys.map(key => acceleratorConfig['global-options'][key].account);
   for (const accountKey of globalAccountKeys) {
-    if (!Object.keys(modifiedConfig['mandatory-accounts-config'].includes(accountKey))) {
+    if (
+      !acceleratorConfig.getMandatoryAccountConfigs().find(accountConfig => {
+        console.log(`Mandatory Account Config Key: ${accountConfig[0]}`);
+        console.log(`Global Options Config Key: accountKey ${accountKey}`);
+        return accountConfig[0] === accountKey;
+      })
+    ) {
       errors.push(`Global mandatory account ${accountKey} was not found under mandatory-account-configs`);
     }
   }

--- a/src/lib/common-config/src/compare/main.ts
+++ b/src/lib/common-config/src/compare/main.ts
@@ -209,8 +209,6 @@ function checkForMismatchedAccountKeys(acceleratorConfig: AcceleratorConfig, err
   for (const accountKey of globalAccountKeys) {
     if (
       !acceleratorConfig.getMandatoryAccountConfigs().find(accountConfig => {
-        console.log(`Mandatory Account Config Key: ${accountConfig[0]}`);
-        console.log(`Global Options Config Key: accountKey ${accountKey}`);
         return accountConfig[0] === accountKey;
       })
     ) {

--- a/src/lib/common-config/src/compare/main.ts
+++ b/src/lib/common-config/src/compare/main.ts
@@ -207,11 +207,7 @@ function checkForMismatchedAccountKeys(acceleratorConfig: AcceleratorConfig, err
   // @ts-ignore
   const globalAccountKeys = mandatoryAccountKeys.map(key => acceleratorConfig['global-options'][key].account);
   for (const accountKey of globalAccountKeys) {
-    if (
-      !acceleratorConfig.getMandatoryAccountConfigs().find(accountConfig => {
-        return accountConfig[0] === accountKey;
-      })
-    ) {
+    if (!acceleratorConfig.getMandatoryAccountConfigs().find(accountConfig => accountConfig[0] === accountKey)) {
       errors.push(`Global mandatory account ${accountKey} was not found under mandatory-account-configs`);
     }
   }

--- a/src/lib/common-config/src/compare/main.ts
+++ b/src/lib/common-config/src/compare/main.ts
@@ -72,6 +72,7 @@ export async function compareAcceleratorConfig(props: {
     // Check for duplicate email entry
     const acceleratorConfig = AcceleratorConfig.fromObject(modifiedConfig);
     checkForEmailDuplicates(acceleratorConfig, errors);
+    checkForMismatchedAccountKeys(modifiedConfig, errors);
     // Validate DDB Pool entries changes
     if (!overrideConfig['ov-cidr']) {
       await validate.validateDDBChanges(
@@ -87,6 +88,7 @@ export async function compareAcceleratorConfig(props: {
   // Check for duplicate email entry
   const acceleratorConfig = AcceleratorConfig.fromObject(modifiedConfig);
   checkForEmailDuplicates(acceleratorConfig, errors);
+  checkForMismatchedAccountKeys(modifiedConfig, errors);
 
   scopeValidation(scope, configChanges, errors, targetAccounts || [], targetOus || []);
 
@@ -193,6 +195,22 @@ function checkForEmailDuplicates(acceleratorConfig: AcceleratorConfig, errors: s
       'Found duplicate entries for account emails under mandatory-account-configs / workload-account-configs',
     );
   }
+}
+
+function checkForMismatchedAccountKeys(modifiedConfig: any, errors: string[]) {
+  const mandatoryAccountKeys = [
+    'aws-org-management',
+    'central-security-services',
+    'central-operations-services',
+    'central-log-services',
+  ];
+  const globalAccountKeys = mandatoryAccountKeys.map(key => modifiedConfig['global-options'][key].account);
+  for (const accountKey of globalAccountKeys) {
+    if (!Object.keys(modifiedConfig['mandatory-accounts-config'].includes(accountKey))) {
+      errors.push(`Global mandatory account ${accountKey} was not found under mandatory-account-configs`);
+    }
+  }
+  return errors;
 }
 
 function scopeValidation(


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

In this PR we:
- Validate that there are no account email duplicates across all accounts.
- We validate that the account entries for the mandatory accounts in global-options exist in the mandatory-account-config
- We add to the validator errors array if any of the above is in violation
