### PR TITLE
Fix/issue 893 - Add optional user-data to Rsyslog config

### DIFF
--- a/src/deployments/cdk/src/deployments/rsyslog/step-2.ts
+++ b/src/deployments/cdk/src/deployments/rsyslog/step-2.ts
@@ -226,6 +226,7 @@ export function createAsg(
     maxInstanceHosts: rsyslogConfig['max-rsyslog-hosts'],
     maxInstanceAge: rsyslogConfig['rsyslog-max-instance-age'],
     enforceImdsv2: rsyslogConfig['rsyslog-enforce-imdsv2'],
+    userData: rsyslogConfig['user-data'],
   });
 }
 

--- a/src/lib/cdk-constructs/src/vpc/asg.ts
+++ b/src/lib/cdk-constructs/src/vpc/asg.ts
@@ -32,6 +32,7 @@ export interface RsysLogAutoScalingGroupProps extends cdk.StackProps {
   maxInstanceHosts: number;
   maxInstanceAge: number;
   enforceImdsv2: boolean;
+  userData?: string;
 }
 
 export class RsysLogAutoScalingGroup extends cdk.Construct {
@@ -82,9 +83,17 @@ export class RsysLogAutoScalingGroup extends cdk.Construct {
       ],
     });
 
-    launchConfig.userData = cdk.Fn.base64(
-      `#!/bin/bash\necho "[v8-stable]\nname=Adiscon CentOS-6 - local packages for \\$basearch\nbaseurl=http://rpms.adiscon.com/v8-stable/epel-6/\\$basearch\nenabled=0\ngpgcheck=0\ngpgkey=http://rpms.adiscon.com/RPM-GPG-KEY-Adiscon\nprotect=1" >> /etc/yum.repos.d/rsyslog.repo\nyum update -y\nyum install -y rsyslog --enablerepo=v8-stable --setopt=v8-stable.priority=1\nchkconfig rsyslog on\naws s3 cp s3://${props.centralBucketName}/rsyslog/rsyslog.conf /etc/rsyslog.conf\nservice rsyslog restart\nwget https://s3.${cdk.Aws.REGION}.amazonaws.com/amazoncloudwatch-agent-${cdk.Aws.REGION}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm\nrpm -U ./amazon-cloudwatch-agent.rpm\ninstanceid=$(curl http://169.254.169.254/latest/meta-data/instance-id)\necho "{\\"logs\\": {\\"logs_collected\\": {\\"files\\": {\\"collect_list\\": [{\\"file_path\\": \\"/var/log/messages\\",\\"log_group_name\\": \\"${props.logGroupName}\\",\\"log_stream_name\\": \\"$instanceid\\"}]}}}}" >> /opt/aws/amazon-cloudwatch-agent/bin/config.json\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -s -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json`,
-    );
+    let launchConfigUserData = `#!/bin/bash\necho "[v8-stable]\nname=Adiscon CentOS-6 - local packages for \\$basearch\nbaseurl=http://rpms.adiscon.com/v8-stable/epel-6/\\$basearch\nenabled=0\ngpgcheck=0\ngpgkey=http://rpms.adiscon.com/RPM-GPG-KEY-Adiscon\nprotect=1" >> /etc/yum.repos.d/rsyslog.repo\nyum update -y\nyum install -y rsyslog --enablerepo=v8-stable --setopt=v8-stable.priority=1\nchkconfig rsyslog on\naws s3 cp s3://${props.centralBucketName}/rsyslog/rsyslog.conf /etc/rsyslog.conf\nservice rsyslog restart\nwget https://s3.${cdk.Aws.REGION}.amazonaws.com/amazoncloudwatch-agent-${cdk.Aws.REGION}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm\nrpm -U ./amazon-cloudwatch-agent.rpm\ninstanceid=$(curl http://169.254.169.254/latest/meta-data/instance-id)\necho "{\\"logs\\": {\\"logs_collected\\": {\\"files\\": {\\"collect_list\\": [{\\"file_path\\": \\"/var/log/messages\\",\\"log_group_name\\": \\"${props.logGroupName}\\",\\"log_stream_name\\": \\"$instanceid\\"}]}}}}" >> /opt/aws/amazon-cloudwatch-agent/bin/config.json\n/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -s -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json`;
+
+    if (props.userData) {
+      /* eslint-disable no-template-curly-in-string */
+      launchConfigUserData = props.userData.replace(
+        new RegExp('\\${SEA:CUSTOM::RsyslogLogGroupName}', 'g'),
+        props.logGroupName,
+      );
+    }
+
+    launchConfig.userData = cdk.Fn.base64(launchConfigUserData);
   }
 }
 

--- a/src/lib/cdk-constructs/src/vpc/asg.ts
+++ b/src/lib/cdk-constructs/src/vpc/asg.ts
@@ -87,10 +87,16 @@ export class RsysLogAutoScalingGroup extends cdk.Construct {
 
     if (props.userData) {
       /* eslint-disable no-template-curly-in-string */
-      launchConfigUserData = props.userData.replace(
-        new RegExp('\\${SEA:CUSTOM::RsyslogLogGroupName}', 'g'),
-        props.logGroupName,
-      );
+      const replaceTokens = new Map([
+        ['\\${SEA:CUSTOM::RsyslogLogGroupName}', props.logGroupName],
+        ['\\${SEA:CUSTOM::Region}', cdk.Aws.REGION],
+        ['\\${SEA:CUSTOM::CentralBucket}', props.centralBucketName],
+      ]);
+
+      launchConfigUserData = props.userData;
+      for (const replaceToken of replaceTokens.entries()) {
+        launchConfigUserData = launchConfigUserData.replace(new RegExp(replaceToken[0], 'g'), replaceToken[1]);
+      }
     }
 
     launchConfig.userData = cdk.Fn.base64(launchConfigUserData);

--- a/src/lib/config-i18n/src/en.ts
+++ b/src/lib/config-i18n/src/en.ts
@@ -1540,6 +1540,10 @@ translate(c.RsyslogConfig, {
       description:
         'The number of days before the auto-scaling group replaces any instance. This ensures a clean image is always deployed and if the state machine has been executed, will deploy the most recent patch release of the AMI.',
     },
+    'user-data': {
+      title: 'user data',
+      description: 'Override the default user data EC2 init script.',
+    },
   },
 });
 

--- a/src/lib/config-i18n/src/fr.ts
+++ b/src/lib/config-i18n/src/fr.ts
@@ -1417,6 +1417,10 @@ translate(c.RsyslogConfig, {
       title: '',
       description: '',
     },
+    'user-data': {
+      title: '',
+      description: '',
+    },
   },
 });
 

--- a/src/lib/config/src/config.v2.ts
+++ b/src/lib/config/src/config.v2.ts
@@ -474,6 +474,7 @@ export const RsyslogConfig = t.interface({
   'rsyslog-enforce-imdsv2': t.defaulted(t.boolean, false),
   'rsyslog-root-volume-size': t.number,
   'rsyslog-max-instance-age': t.number,
+  'user-data': t.optional(t.nonEmptyString),
 });
 
 export type RsyslogConfig = t.TypeOf<typeof RsyslogConfig>;


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Summary
This update adds `user-data` to the `rsyslog` deployment type. The issue in #893 can be remediated by changing the user data script.

The following token was added to allow a string replace in the user-data string value. `${SEA:CUSTOM::RsyslogLogGroupName}` 