### PR TITLE
Added new optional parameter --CoreOU to specify the core OU name.

### DIFF
--- a/reference-artifacts/Custom-Scripts/Update-Scripts/v1.3.8_to_v1.5.0/README.md
+++ b/reference-artifacts/Custom-Scripts/Update-Scripts/v1.3.8_to_v1.5.0/README.md
@@ -3,7 +3,7 @@
 Usage:
 
 ```
-update.py [-h] [--AcceleratorPrefix ACCELERATORPREFIX] --ConfigFile
+update.py [-h] [--AcceleratorPrefix ACCELERATORPREFIX] [--CoreOU COREOUNAME]--ConfigFile
                  CONFIGFILE --Region REGION [--LoadDB] [--LoadConfig]
 ```
 
@@ -16,6 +16,7 @@ Optional arguments:
   -h, --help            show this help message and exit
   --AcceleratorPrefix ACCELERATORPREFIX
                         The value set in AcceleratorPrefix
+  --CoreOU COREOUNAME   Optional parameter. Defaults to core. The name of the core OU.
   --ConfigFile CONFIGFILE
                         ConfigFile location
   --Region REGION       Region in which SEA is deployed


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Some implementations do no use the core OU default name ('core'). The new flag enables support for such cases. Without the flag the Infrastructure OU is not properly populated and the core OU is not renamed to Security.
