### PR TITLE
fix for cwl additional region permission bug

### DIFF
--- a/src/deployments/cdk/src/deployments/central-services/central-logging-s3/step-1.ts
+++ b/src/deployments/cdk/src/deployments/central-services/central-logging-s3/step-1.ts
@@ -88,7 +88,7 @@ export async function step1(props: CentralLoggingToS3Step1Props) {
       logStreamRoleArn: cwlLogStreamRoleOutput.roleArn,
       kinesisStreamRoleArn: cwlKinesisStreamRoleOutput.roleArn,
       dynamicS3LogPartitioning: centralLogServices['dynamic-s3-log-partitioning'],
-      region
+      region,
     });
   }
 }
@@ -105,7 +105,7 @@ async function cwlSettingsInLogArchive(props: {
   kinesisStreamRoleArn: string;
   shardCount?: number;
   dynamicS3LogPartitioning?: c.S3LogPartition[];
-  region: string
+  region: string;
 }) {
   const {
     scope,
@@ -115,7 +115,7 @@ async function cwlSettingsInLogArchive(props: {
     kinesisStreamRoleArn,
     shardCount,
     dynamicS3LogPartitioning,
-    region
+    region,
   } = props;
 
   // Create Kinesis Stream for Logs streaming

--- a/src/deployments/cdk/src/deployments/central-services/central-logging-s3/step-1.ts
+++ b/src/deployments/cdk/src/deployments/central-services/central-logging-s3/step-1.ts
@@ -88,6 +88,7 @@ export async function step1(props: CentralLoggingToS3Step1Props) {
       logStreamRoleArn: cwlLogStreamRoleOutput.roleArn,
       kinesisStreamRoleArn: cwlKinesisStreamRoleOutput.roleArn,
       dynamicS3LogPartitioning: centralLogServices['dynamic-s3-log-partitioning'],
+      region
     });
   }
 }
@@ -104,6 +105,7 @@ async function cwlSettingsInLogArchive(props: {
   kinesisStreamRoleArn: string;
   shardCount?: number;
   dynamicS3LogPartitioning?: c.S3LogPartition[];
+  region: string
 }) {
   const {
     scope,
@@ -113,6 +115,7 @@ async function cwlSettingsInLogArchive(props: {
     kinesisStreamRoleArn,
     shardCount,
     dynamicS3LogPartitioning,
+    region
   } = props;
 
   // Create Kinesis Stream for Logs streaming
@@ -168,7 +171,7 @@ async function cwlSettingsInLogArchive(props: {
     },
   });
 
-  const kinesisStreamRole = iam.Role.fromRoleArn(scope, 'KinesisStreamRoleLookup', kinesisStreamRoleArn, {
+  const kinesisStreamRole = iam.Role.fromRoleArn(scope, `KinesisStreamRoleLookup-${region}`, kinesisStreamRoleArn, {
     mutable: true,
   });
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The State Machine (SM) fails to complete *Deploy Phase 1* when the following configuration is applied:

```
 "additional-cwl-regions": {
      "us-east-1": {
        "kinesis-stream-shard-count": 1
      }
    },
```

It errors with: **"KinesisStreamRoleLookupPolicyB898FB3A already exists on the role PBMMAccel-Kinesis-Stream-Role-C25E0F50**

This pull request (PR) fixes that issue.
 