### PR TITLE
fix for Log Archive Bucket Resource Policies being overwritten 

### DIFF
--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/cdk/index.ts
@@ -26,6 +26,7 @@ export interface LogArchiveReadAccessProps {
   aesLogBucket: s3.IBucket;
   removalPolicy?: cdk.RemovalPolicy;
   acceleratorPrefix: string;
+  forceUpdate?: boolean;
 }
 
 /**
@@ -53,6 +54,12 @@ export class S3UpdateLogArchivePolicy extends cdk.Construct {
       aesLogBucketArn: this.props.aesLogBucket.bucketArn,
       aesLogBucketName: this.props.aesLogBucket.bucketName,
     };
+
+    const forceUpdate = this.props.forceUpdate ?? true;
+    if (forceUpdate) {
+      // Add a dummy value that is a random number to update the resource every time
+      handlerProperties.forceUpdate = Math.round(Math.random() * 1000000);
+    }
 
     this.resource = new cdk.CustomResource(this, 'Resource', {
       resourceType,

--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
@@ -28,6 +28,7 @@ export interface HandlerProperties {
   logBucketKmsKeyArn: string | undefined;
   aesLogBucketArn: string;
   aesLogBucketName: string;
+  forceUpdate?: number;
 }
 
 export const handler = errorHandler(onEvent);
@@ -215,7 +216,14 @@ async function onCreate(event: CloudFormationCustomResourceCreateEvent) {
 
 async function onUpdate(event: CloudFormationCustomResourceUpdateEvent) {
   const props = getPropertiesFromEvent(event);
-  await createOrUpdateBucketPolicy(props);
+
+  if (props.forceUpdate !== undefined) {
+    console.log('onUpdate forceUpdate true');
+    await createOrUpdateBucketPolicy(props);
+  } else {
+    console.log('onUpdate skipped');
+  }
+    
   return { physicalResourceId: event.PhysicalResourceId };
 }
 

--- a/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
+++ b/src/lib/custom-resources/cdk-s3-update-logarchive-bucket-policy/runtime/src/index.ts
@@ -223,7 +223,7 @@ async function onUpdate(event: CloudFormationCustomResourceUpdateEvent) {
   } else {
     console.log('onUpdate skipped');
   }
-    
+
   return { physicalResourceId: event.PhysicalResourceId };
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

In some scenarios it is possible that the SM runs that affects the Log Archive S3 Resource Policies without triggering the execution of the **cdk-s3-update-logarchive-bucket-policy** lambda function. This could happen if CloudFormation does not detect/update the lambda function. The result is the custom resource policies are not reapplied. 

This Pull Request 'forces' the update of the **cdk-s3-update-logarchive-bucket-policy** lambda function; thus forcing it to fire each SM run.

To validate the fix:
1. Run the SM and log into the Log Archive Account
2. Locate the lambda function example **ASEA-LogArchive-Phase2-CustomS3UpdateLogArchivePol-jTScdLLzleff** 
3. View its CloudWatch Logs
4. Validate that entry similar to the following exists:
```
2022-02-17T19:14:49.651-08:00 | 2022-02-18T03:14:49.651Z 9ba2c4e9-5d29-4094-a85e-8ae2ffb73330 INFO onUpdate forceUpdate true
```