### PR TITLE
update opensearch aws-cdk to latest

### DIFF
--- a/reference-artifacts/Add-ons/opensiem/package-lock.json
+++ b/reference-artifacts/Add-ons/opensiem/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-asea-opensearch-siem",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.10.0",
+        "aws-cdk-lib": "2.13.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.16"
       },
@@ -20,7 +20,7 @@
         "@types/node": "10.17.27",
         "@typescript-eslint/eslint-plugin": "4.22.0",
         "@typescript-eslint/parser": "4.22.0",
-        "aws-cdk": "2.10.0",
+        "aws-cdk": "2.13.0",
         "eslint": "7.25.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-deprecation": "1.2.0",
@@ -1632,28 +1632,28 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.10.0.tgz",
-      "integrity": "sha512-abLruZeyj9+1Uc+1u0cN+5c7PWl4Y6yC30/nFnRD6fCxu06Ad4mXujkaow5Vh/ROAOpaRUcNMdfbbx/dNyMZ5g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.13.0.tgz",
+      "integrity": "sha512-CJy+6guWMklKesZezkYcGdruDL8qGx3SdFMLQ47OgJrwy0QiCyGWrceacHvwl7ebQk7HtWU8dHHCfaEsY0RHXw==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "2.10.0",
-        "@aws-cdk/cloudformation-diff": "2.10.0",
-        "@aws-cdk/cx-api": "2.10.0",
-        "@aws-cdk/region-info": "2.10.0",
-        "@jsii/check-node": "1.52.1",
+        "@aws-cdk/cloud-assembly-schema": "2.13.0",
+        "@aws-cdk/cloudformation-diff": "2.13.0",
+        "@aws-cdk/cx-api": "2.13.0",
+        "@aws-cdk/region-info": "2.13.0",
+        "@jsii/check-node": "1.54.0",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.979.0",
         "camelcase": "^6.3.0",
-        "cdk-assets": "2.10.0",
+        "cdk-assets": "2.13.0",
         "chalk": "^4",
         "chokidar": "^3.5.3",
         "decamelize": "^5.0.1",
         "fs-extra": "^9.1.0",
         "glob": "^7.2.0",
         "json-diff": "^0.7.1",
-        "minimatch": ">=3.0",
+        "minimatch": ">=3.1",
         "promptly": "^3.2.0",
         "proxy-agent": "^5.0.0",
         "semver": "^7.3.5",
@@ -1673,9 +1673,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.10.0.tgz",
-      "integrity": "sha512-sMQvQzDqfHumbDOwH2nnyu/sKl7HMi4LkIDRlhW/dLZhYiLvEbwA8ZUclY9g5NuSihF+3G9x1uOjBETBGp+rTg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.13.0.tgz",
+      "integrity": "sha512-nKpQk+9H7T128gpzl+7XTu+19Yzj6kmCMrvSwTXLa/qr4/soEpXI68/+19ymEAHOYEL4Dd3eyk490P+y0wzi6A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1693,7 +1693,7 @@
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
         "jsonschema": "^1.4.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.5",
         "yaml": "1.10.2"
@@ -1803,7 +1803,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.0.4",
+      "version": "3.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1857,7 +1857,7 @@
       }
     },
     "node_modules/aws-cdk/node_modules/@aws-cdk/cfnspec": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true,
       "dependencies": {
         "fs-extra": "^9.1.0",
@@ -1865,7 +1865,7 @@
       }
     },
     "node_modules/aws-cdk/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true,
       "dependencies": {
         "jsonschema": "^1.4.0",
@@ -1873,10 +1873,10 @@
       }
     },
     "node_modules/aws-cdk/node_modules/@aws-cdk/cloudformation-diff": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true,
       "dependencies": {
-        "@aws-cdk/cfnspec": "2.10.0",
+        "@aws-cdk/cfnspec": "2.13.0",
         "@types/node": "^10.17.60",
         "chalk": "^4",
         "diff": "^5.0.0",
@@ -1886,21 +1886,21 @@
       }
     },
     "node_modules/aws-cdk/node_modules/@aws-cdk/cx-api": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true,
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "2.10.0",
+        "@aws-cdk/cloud-assembly-schema": "2.13.0",
         "semver": "^7.3.5"
       }
     },
     "node_modules/aws-cdk/node_modules/@aws-cdk/region-info": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/@jsii/check-node": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.52.1.tgz#e14101294593ec41b76812acf5ba9c06e0cbfef2",
-      "integrity": "sha512-B+vpPwXrKTWA1dBHuStp0sg+YpFZ9APjS6qeDiknMHPMatlT7VA0RVk/LmCLaPZhsfNzByJ+zhRFs0R83zTr1Q==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.54.0.tgz#6cee236d2267c1d4df4cd58aacffdf7fbf87ebe7",
+      "integrity": "sha512-pogNR1vgiXgBK2DQF+RsCnJQ9QPe+y7lyoRlsTtUplIFB6ryWnSsmCyzkInSVoKAKCo5CHkuDy190MbYL4Ns4Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -1919,6 +1919,18 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "dev": true
     },
+    "node_modules/aws-cdk/node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "node_modules/aws-cdk/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "node_modules/aws-cdk/node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
@@ -1929,9 +1941,9 @@
       }
     },
     "node_modules/aws-cdk/node_modules/ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d",
+      "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2041,9 +2053,9 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/aws-sdk": {
-      "version": "2.1063.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz#ab5e7f69955358a48be345ee3d76667a68f61dd6",
-      "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
+      "version": "2.1074.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1074.0.tgz#be3283f781b3060cd67d5abef50d1edacefede70",
+      "integrity": "sha512-tD478mkukglutjs+mq5FQmYFzz+l/wddl5u3tTMWTNa+j1eSL+AqaHPFM1rC3O9h98QqpKKzeKbLrPhGDvYaRg==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2157,9 +2169,9 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/camelcase": {
@@ -2169,11 +2181,11 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/cdk-assets": {
-      "version": "2.10.0",
+      "version": "2.13.0",
       "dev": true,
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "2.10.0",
-        "@aws-cdk/cx-api": "2.10.0",
+        "@aws-cdk/cloud-assembly-schema": "2.13.0",
+        "@aws-cdk/cx-api": "2.13.0",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.848.0",
         "glob": "^7.2.0",
@@ -2507,9 +2519,9 @@
       }
     },
     "node_modules/aws-cdk/node_modules/ext/node_modules/type": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d",
-      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/fast-deep-equal": {
@@ -2661,6 +2673,15 @@
       "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "node_modules/aws-cdk/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "node_modules/aws-cdk/node_modules/graceful-fs": {
@@ -2972,12 +2993,21 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.0.tgz#281d8402aaaeed18a9e8406ad99c46a19206c6ef",
+      "integrity": "sha512-EU+GCVjXD00yOUf1TwAHVP7v3fBD3A8RkkPYsWWKGWesxM/572sL53wJQnHxquHlRhYUV36wHkqrN8cdikKc2g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
+      }
+    },
+    "node_modules/aws-cdk/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/aws-cdk/node_modules/ms": {
@@ -3150,12 +3180,12 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz#baf3e9c21eebced59dd6533ac872b71f7b61cb32",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c",
+      "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
       "dev": true,
       "dependencies": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
@@ -3203,6 +3233,15 @@
       "dev": true,
       "dependencies": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "node_modules/aws-cdk/node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
       }
     },
     "node_modules/aws-cdk/node_modules/readdirp": {
@@ -3277,13 +3316,13 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "dev": true,
       "dependencies": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "smart-buffer": "^4.2.0"
       }
     },
     "node_modules/aws-cdk/node_modules/socks-proxy-agent": {
@@ -3485,10 +3524,14 @@
       "dev": true
     },
     "node_modules/aws-cdk/node_modules/vm2": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496",
-      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
-      "dev": true
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz#e99c000db042735cd2f94d8db6c42163a17be04e",
+      "integrity": "sha512-/1PYg/BwdKzMPo8maOZ0heT7DLI0DAFTm7YQaz/Lim9oIaFZsJs3EdtalvXuBfZwczNwsYhju75NW4d6E+4q+w==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      }
     },
     "node_modules/aws-cdk/node_modules/word-wrap": {
       "version": "1.2.3",
@@ -3708,8 +3751,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base": {
       "version": "0.11.2",
@@ -3745,7 +3787,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4147,8 +4188,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/constructs": {
       "version": "10.0.54",
@@ -7713,7 +7753,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -11734,27 +11773,27 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.10.0.tgz",
-      "integrity": "sha512-abLruZeyj9+1Uc+1u0cN+5c7PWl4Y6yC30/nFnRD6fCxu06Ad4mXujkaow5Vh/ROAOpaRUcNMdfbbx/dNyMZ5g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.13.0.tgz",
+      "integrity": "sha512-CJy+6guWMklKesZezkYcGdruDL8qGx3SdFMLQ47OgJrwy0QiCyGWrceacHvwl7ebQk7HtWU8dHHCfaEsY0RHXw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/cloud-assembly-schema": "2.10.0",
-        "@aws-cdk/cloudformation-diff": "2.10.0",
-        "@aws-cdk/cx-api": "2.10.0",
-        "@aws-cdk/region-info": "2.10.0",
-        "@jsii/check-node": "1.52.1",
+        "@aws-cdk/cloud-assembly-schema": "2.13.0",
+        "@aws-cdk/cloudformation-diff": "2.13.0",
+        "@aws-cdk/cx-api": "2.13.0",
+        "@aws-cdk/region-info": "2.13.0",
+        "@jsii/check-node": "1.54.0",
         "archiver": "^5.3.0",
         "aws-sdk": "^2.979.0",
         "camelcase": "^6.3.0",
-        "cdk-assets": "2.10.0",
+        "cdk-assets": "2.13.0",
         "chalk": "^4",
         "chokidar": "^3.5.3",
         "decamelize": "^5.0.1",
         "fs-extra": "^9.1.0",
         "glob": "^7.2.0",
         "json-diff": "^0.7.1",
-        "minimatch": ">=3.0",
+        "minimatch": ">=3.1",
         "promptly": "^3.2.0",
         "proxy-agent": "^5.0.0",
         "semver": "^7.3.5",
@@ -11768,7 +11807,7 @@
       },
       "dependencies": {
         "@aws-cdk/cfnspec": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true,
           "requires": {
             "fs-extra": "^9.1.0",
@@ -11776,7 +11815,7 @@
           }
         },
         "@aws-cdk/cloud-assembly-schema": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true,
           "requires": {
             "jsonschema": "^1.4.0",
@@ -11784,10 +11823,10 @@
           }
         },
         "@aws-cdk/cloudformation-diff": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true,
           "requires": {
-            "@aws-cdk/cfnspec": "2.10.0",
+            "@aws-cdk/cfnspec": "2.13.0",
             "@types/node": "^10.17.60",
             "chalk": "^4",
             "diff": "^5.0.0",
@@ -11797,21 +11836,21 @@
           }
         },
         "@aws-cdk/cx-api": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "2.10.0",
+            "@aws-cdk/cloud-assembly-schema": "2.13.0",
             "semver": "^7.3.5"
           }
         },
         "@aws-cdk/region-info": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true
         },
         "@jsii/check-node": {
-          "version": "1.52.1",
-          "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.52.1.tgz#e14101294593ec41b76812acf5ba9c06e0cbfef2",
-          "integrity": "sha512-B+vpPwXrKTWA1dBHuStp0sg+YpFZ9APjS6qeDiknMHPMatlT7VA0RVk/LmCLaPZhsfNzByJ+zhRFs0R83zTr1Q==",
+          "version": "1.54.0",
+          "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.54.0.tgz#6cee236d2267c1d4df4cd58aacffdf7fbf87ebe7",
+          "integrity": "sha512-pogNR1vgiXgBK2DQF+RsCnJQ9QPe+y7lyoRlsTtUplIFB6ryWnSsmCyzkInSVoKAKCo5CHkuDy190MbYL4Ns4Q==",
           "dev": true,
           "requires": {
             "chalk": "^4.1.2",
@@ -11830,6 +11869,18 @@
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
           "dev": true
         },
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
         "agent-base": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77",
@@ -11840,9 +11891,9 @@
           }
         },
         "ajv": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18",
-          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz#e573f719bd3af069017e3b66538ab968d040e54d",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -11954,9 +12005,9 @@
           "dev": true
         },
         "aws-sdk": {
-          "version": "2.1063.0",
-          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1063.0.tgz#ab5e7f69955358a48be345ee3d76667a68f61dd6",
-          "integrity": "sha512-UonfKdsDChKEmAkFuDOQ8zeilvR5v7d5dEcWDy+fnKBs+6HGjDThMf7EofhOiKxOXWnFhrAsFKCsKDcfeA6NBg==",
+          "version": "2.1074.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1074.0.tgz#be3283f781b3060cd67d5abef50d1edacefede70",
+          "integrity": "sha512-tD478mkukglutjs+mq5FQmYFzz+l/wddl5u3tTMWTNa+j1eSL+AqaHPFM1rC3O9h98QqpKKzeKbLrPhGDvYaRg==",
           "dev": true,
           "requires": {
             "buffer": "4.9.2",
@@ -12074,9 +12125,9 @@
           "dev": true
         },
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz#3f018291cb4cbad9accb6e6970bca9c8889e879a",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
           "dev": true
         },
         "camelcase": {
@@ -12086,11 +12137,11 @@
           "dev": true
         },
         "cdk-assets": {
-          "version": "2.10.0",
+          "version": "2.13.0",
           "dev": true,
           "requires": {
-            "@aws-cdk/cloud-assembly-schema": "2.10.0",
-            "@aws-cdk/cx-api": "2.10.0",
+            "@aws-cdk/cloud-assembly-schema": "2.13.0",
+            "@aws-cdk/cx-api": "2.13.0",
             "archiver": "^5.3.0",
             "aws-sdk": "^2.848.0",
             "glob": "^7.2.0",
@@ -12424,9 +12475,9 @@
           },
           "dependencies": {
             "type": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d",
-              "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+              "version": "2.6.0",
+              "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f",
+              "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
               "dev": true
             }
           }
@@ -12575,6 +12626,17 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "glob-parent": {
@@ -12899,12 +12961,23 @@
           "dev": true
         },
         "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.0.tgz#281d8402aaaeed18a9e8406ad99c46a19206c6ef",
+          "integrity": "sha512-EU+GCVjXD00yOUf1TwAHVP7v3fBD3A8RkkPYsWWKGWesxM/572sL53wJQnHxquHlRhYUV36wHkqrN8cdikKc2g==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
           }
         },
         "ms": {
@@ -13079,12 +13152,12 @@
           "dev": true
         },
         "raw-body": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz#baf3e9c21eebced59dd6533ac872b71f7b61cb32",
-          "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz#8f80305d11c2a0a545c2d9d89d7a0286fcead43c",
+          "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
           "dev": true,
           "requires": {
-            "bytes": "3.1.1",
+            "bytes": "3.1.2",
             "http-errors": "1.8.1",
             "iconv-lite": "0.4.24",
             "unpipe": "1.0.0"
@@ -13134,6 +13207,17 @@
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "readdirp": {
@@ -13208,13 +13292,13 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e",
-          "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a",
+          "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
           "dev": true,
           "requires": {
             "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "smart-buffer": "^4.2.0"
           }
         },
         "socks-proxy-agent": {
@@ -13420,10 +13504,14 @@
           "dev": true
         },
         "vm2": {
-          "version": "3.9.5",
-          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496",
-          "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==",
-          "dev": true
+          "version": "3.9.8",
+          "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz#e99c000db042735cd2f94d8db6c42163a17be04e",
+          "integrity": "sha512-/1PYg/BwdKzMPo8maOZ0heT7DLI0DAFTm7YQaz/Lim9oIaFZsJs3EdtalvXuBfZwczNwsYhju75NW4d6E+4q+w==",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.7.0",
+            "acorn-walk": "^8.2.0"
+          }
         },
         "word-wrap": {
           "version": "1.2.3",
@@ -13537,16 +13625,16 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.10.0.tgz",
-      "integrity": "sha512-sMQvQzDqfHumbDOwH2nnyu/sKl7HMi4LkIDRlhW/dLZhYiLvEbwA8ZUclY9g5NuSihF+3G9x1uOjBETBGp+rTg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.13.0.tgz",
+      "integrity": "sha512-nKpQk+9H7T128gpzl+7XTu+19Yzj6kmCMrvSwTXLa/qr4/soEpXI68/+19ymEAHOYEL4Dd3eyk490P+y0wzi6A==",
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
         "jsonschema": "^1.4.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
         "semver": "^7.3.5",
         "yaml": "1.10.2"
@@ -13618,7 +13706,7 @@
           }
         },
         "minimatch": {
-          "version": "3.0.4",
+          "version": "3.1.2",
           "bundled": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -13738,8 +13826,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -13771,7 +13858,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -14085,8 +14171,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "constructs": {
       "version": "10.0.54",
@@ -16786,7 +16871,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/reference-artifacts/Add-ons/opensiem/package.json
+++ b/reference-artifacts/Add-ons/opensiem/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "2.10.0",
+    "aws-cdk": "2.13.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
@@ -37,7 +37,7 @@
     "eslint-plugin-unicorn": "31.0.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.10.0",
+    "aws-cdk-lib": "2.13.0",
     "constructs": "^10.0.0",    
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This updates cdk from 2.10.0 to 2.13.0 and resolves npm audit findings