### PR TITLE
fix perms where fms would fail to publish to sns

### DIFF
--- a/src/deployments/cdk/src/apps/phase-1.ts
+++ b/src/deployments/cdk/src/apps/phase-1.ts
@@ -120,6 +120,7 @@ export async function deploy({ acceleratorConfig, accountStacks, accounts, conte
     accountStacks,
     centralLogBucket: logBucket,
     config: acceleratorConfig,
+    prefix: context.acceleratorPrefix,
   });
 
   /**

--- a/src/deployments/cdk/src/deployments/defaults/shared.ts
+++ b/src/deployments/cdk/src/deployments/defaults/shared.ts
@@ -18,15 +18,16 @@ import { Bucket } from '@aws-accelerator/cdk-constructs/src/s3';
 import { createEncryptionKeyName } from '@aws-accelerator/cdk-accelerator/src/core/accelerator-name-generator';
 import { AccountStack } from '../../common/account-stacks';
 import { overrideLogicalId } from '../../utils/cdk';
+import { Organizations } from '@aws-accelerator/custom-resource-organization';
 
 export interface KmsDetails {
   encryptionKey: kms.Key;
   alias: string;
 }
 
-export function createDefaultS3Key(props: { accountStack: AccountStack }): KmsDetails {
+export function createDefaultS3Key(props: { accountStack: AccountStack; prefix: string }): KmsDetails {
   const { accountStack } = props;
-
+  const organization = new Organizations(accountStack, 'Organization');
   const keyAlias = createEncryptionKeyName('Bucket-Key');
   const encryptionKey = new kms.Key(accountStack, 'DefaultKey', {
     alias: `alias/${keyAlias}`,
@@ -53,6 +54,22 @@ export function createDefaultS3Key(props: { accountStack: AccountStack }): KmsDe
         new iam.ServicePrincipal('macie.amazonaws.com'),
       ],
       resources: ['*'],
+    }),
+  );
+  encryptionKey.addToResourcePolicy(
+    new iam.PolicyStatement({
+      sid: 'Allow AWS services to use the encryption key',
+      actions: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
+      principals: [new iam.AnyPrincipal()],
+      resources: ['*'],
+      conditions: {
+        StringEquals: {
+          'aws:PrincipalOrgID': organization.organizationId,
+        },
+        StringLike: {
+          'aws:PrincipalArn': `arn:aws:iam::*:role/${props.prefix}*`,
+        },
+      },
     }),
   );
 

--- a/src/deployments/cdk/src/deployments/defaults/shared.ts
+++ b/src/deployments/cdk/src/deployments/defaults/shared.ts
@@ -44,7 +44,7 @@ export function createDefaultS3Key(props: { accountStack: AccountStack; prefix: 
   );
   encryptionKey.addToResourcePolicy(
     new iam.PolicyStatement({
-      sid: 'Allow AWS services to use the encryption key',
+      sid: 'Allow ASEA Roles to use the encryption key',
       actions: ['kms:Encrypt', 'kms:Decrypt', 'kms:ReEncrypt*', 'kms:GenerateDataKey*', 'kms:DescribeKey'],
       principals: [
         new iam.ServicePrincipal('sns.amazonaws.com'),

--- a/src/deployments/cdk/src/deployments/defaults/step-1.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-1.ts
@@ -571,7 +571,7 @@ function createKeyAndOutput(
   // Default EBS encryption key
   const key = createDefaultS3Key({
     accountStack,
-    prefix: prefix,
+    prefix,
   }).encryptionKey;
 
   defaultEncryptionKeys[accountStack.accountKey] = {

--- a/src/deployments/cdk/src/deployments/defaults/step-1.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-1.ts
@@ -17,7 +17,6 @@ import * as kms from '@aws-cdk/aws-kms';
 import * as s3 from '@aws-cdk/aws-s3';
 import { RegionInfo } from '@aws-cdk/region-info';
 import { EbsDefaultEncryption } from '@aws-accelerator/custom-resource-ec2-ebs-default-encryption';
-import { S3CopyFiles } from '@aws-accelerator/custom-resource-s3-copy-files';
 import { S3PublicAccessBlock } from '@aws-accelerator/custom-resource-s3-public-access-block';
 import { Organizations } from '@aws-accelerator/custom-resource-organization';
 import { AcceleratorConfig } from '@aws-accelerator/common-config/src';
@@ -191,7 +190,6 @@ function createCentralBucketCopy(props: DefaultsStep1Props) {
  */
 function createCentralLogBucket(props: DefaultsStep1Props) {
   const { accountStacks, config } = props;
-
   const logAccountConfig = config['global-options']['central-log-services'];
   const logAccountStack = accountStacks.getOrCreateAccountStack(logAccountConfig.account);
 
@@ -200,6 +198,7 @@ function createCentralLogBucket(props: DefaultsStep1Props) {
   const anyAccountPrincipal = [new iam.AnyPrincipal()];
   const logKey = createDefaultS3Key({
     accountStack: logAccountStack,
+    prefix: props.acceleratorPrefix,
   });
 
   const defaultLogRetention = config['global-options']['central-log-services']['s3-retention'];
@@ -546,7 +545,7 @@ function createDefaultEncryptionKeys(props: DefaultsStep1Props): LogAccountDefau
       console.warn(`Cannot find ${accountStack} stack in ${region}`);
       continue;
     }
-    createKeyAndOutput(accountStack, region, defaultEncryptionKeys);
+    createKeyAndOutput(accountStack, region, defaultEncryptionKeys, props.acceleratorPrefix);
     // If add-sns-topic is set true for the security account, create a default key in other regions there as well
     if (centralSecurityServices['add-sns-topics']) {
       const accountStack = accountStacks.tryGetOrCreateAccountStack(centralSecurityServices.account, region);
@@ -554,7 +553,7 @@ function createDefaultEncryptionKeys(props: DefaultsStep1Props): LogAccountDefau
         console.warn(`Cannot find ${accountStack} stack in ${region}`);
         continue;
       }
-      createKeyAndOutput(accountStack, region, defaultEncryptionKeys);
+      createKeyAndOutput(accountStack, region, defaultEncryptionKeys, props.acceleratorPrefix);
     }
   }
 
@@ -565,11 +564,15 @@ function createKeyAndOutput(
   accountStack: AccountStack,
   region: string,
   defaultEncryptionKeys: LogAccountDefaultEncryptionKeys,
+  prefix: string,
 ) {
   // Create a default EBS encryption key for every other region of the log account
   const keyAlias = createEncryptionKeyName('Default-Key');
   // Default EBS encryption key
-  const key = createDefaultS3Key({ accountStack }).encryptionKey;
+  const key = createDefaultS3Key({
+    accountStack,
+    prefix: prefix,
+  }).encryptionKey;
 
   defaultEncryptionKeys[accountStack.accountKey] = {
     ...defaultEncryptionKeys[accountStack.accountKey],

--- a/src/deployments/cdk/src/deployments/defaults/step-2.ts
+++ b/src/deployments/cdk/src/deployments/defaults/step-2.ts
@@ -26,6 +26,7 @@ export interface DefaultsStep2Props {
   accounts: Account[];
   config: AcceleratorConfig;
   centralLogBucket: s3.IBucket;
+  prefix: string;
 }
 
 export type DefaultsStep2Result = AccountBuckets;
@@ -59,6 +60,7 @@ function createDefaultS3Buckets(props: DefaultsStep2Props) {
 
     const key = createDefaultS3Key({
       accountStack,
+      prefix: props.prefix,
     });
 
     const defaultLogRetention = config['global-options']['default-s3-retention'];


### PR DESCRIPTION
fms custom resource would fail on phase 4 because the ASEA pipeline role did not have the correct permissions for KMS. This fix gives the pipeline role correct permissions to the key.