### PR TITLE
fix yaml load and log bucket output error

### DIFF
--- a/src/deployments/cdk/src/deployments/iam/step-1.ts
+++ b/src/deployments/cdk/src/deployments/iam/step-1.ts
@@ -16,7 +16,7 @@ import * as iam from '@aws-cdk/aws-iam';
 import { AccountStacks } from '../../common/account-stacks';
 import { createRoleName } from '@aws-accelerator/cdk-accelerator/src/core/accelerator-name-generator';
 import { CfnIamRoleOutput } from './outputs';
-import { LogBucketOutput, AccountBucketOutputFinder } from '../defaults/outputs';
+import { LogBucketOutput } from '../defaults/outputs';
 import { StackOutput } from '@aws-accelerator/common-outputs/src/stack-output';
 
 export interface IamConfigServiceRoleProps {
@@ -35,12 +35,16 @@ export async function createConfigServiceRoles(props: IamConfigServiceRoleProps)
   const securityAccountKey = config.getMandatoryAccountKey('central-security');
   const centralOperationsKey = config.getMandatoryAccountKey('central-operations');
   const centralLogKey = config.getMandatoryAccountKey('central-log');
-
-  const logBucketDetails = LogBucketOutput.getBucket({
-    accountStacks,
-    config,
-    outputs,
-  });
+  let logBucketDetails;
+  try {
+    logBucketDetails = LogBucketOutput.getBucket({
+      accountStacks,
+      config,
+      outputs,
+    });
+  } catch (err) {
+    console.log(err);
+  }
 
   for (const accountKey of accountKeys) {
     const accountStack = accountStacks.tryGetOrCreateAccountStack(accountKey);

--- a/src/deployments/cdk/src/deployments/iam/step-1.ts
+++ b/src/deployments/cdk/src/deployments/iam/step-1.ts
@@ -43,7 +43,7 @@ export async function createConfigServiceRoles(props: IamConfigServiceRoleProps)
       outputs,
     });
   } catch (err) {
-    console.log(err);
+    console.log('Log Bucket not created yet. Continuing.');
   }
 
   for (const accountKey of accountKeys) {

--- a/src/lib/common/src/util/common.ts
+++ b/src/lib/common/src/util/common.ts
@@ -355,6 +355,6 @@ function enableGlobalRegion(config: string, rawConfig: string, format: FormatTyp
   }
 
   const configStr = getStringFromObject(configObj, format);
-  const rawConfigStr = getStringFromObject(rawConfigObj, format);
+  const rawConfigStr = getStringFromObject(rawConfigObj, JSON_FORMAT);
   return { configStr, rawConfigStr };
 }


### PR DESCRIPTION
This resolves the error when loading a yaml config file.

This also resolves the error "Error: Cannot find central log bucket for log account log-archive"

fixes #945 