### PR TITLE
fix: update SnsSubscriber lambda role permissions to support KMS SNS Topics

### DIFF
--- a/src/deployments/cdk/src/deployments/iam/sns-subscriber-lambda-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/sns-subscriber-lambda-role.ts
@@ -83,6 +83,13 @@ function createRole(accountStack: AccountStack) {
     }),
   );
 
+  role.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      actions: ['kms:Encrypt', 'kms:Decrypt', 'kms:GenerateDataKey'],
+      resources: ['*'],
+    }),
+  );
+
   new CfnIamRoleOutput(accountStack, `SnsSubscriberLambdaOutput`, {
     roleName: role.roleName,
     roleArn: role.roleArn,


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The root account **ASEA-Management-Phase2-SnsSubscriberLambda** function fails to publish messages to the central account SNS KMS encrypted topics. This pull request updates the Lambda's role permissions to allow the use of KMS.

This issue can be identified by the lack of notifications and viewing the following error in the CloudWatch Logs for the lambda:
```
{
    "errorType": "KMSAccessDenied",
    "errorMessage": "null (Service: AWSKMS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 318a7abf-00c8-4b1d-8877-cb1fba8271e5; Proxy: null)",
    "code": "KMSAccessDenied",
    "message": "null (Service: AWSKMS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 318a7abf-00c8-4b1d-8877-cb1fba8271e5; Proxy: null)",
    "time": "2022-05-15T18:47:54.005Z",
    "requestId": "3d74811c-76e1-541c-bf98-dbe73bf8df4f",
    "statusCode": 400,
    "retryable": false,
    "retryDelay": 64.39261711722328,
    "stack": [
        "KMSAccessDenied: null (Service: AWSKMS; Status Code: 400; Error Code: AccessDeniedException; Request ID: 318a7abf-00c8-4b1d-8877-cb1fba8271e5; Proxy: null)",
        "    at Request.extractError (/var/runtime/node_modules/aws-sdk/lib/protocol/query.js:50:29)",
        "    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:106:20)",
        "    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:78:10)",
        "    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:686:14)",
        "    at Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)",
        "    at AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)",
        "    at /var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10",
        "    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9)",
        "    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:688:12)",
        "    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:116:18)"
    ]
}
```