### PR TITLE
Filter out Organizational accounts not in the ACTIVE state

### DIFF
--- a/reference-artifacts/Custom-Scripts/SEA-uninstall/aws-sea-cleanup.py
+++ b/reference-artifacts/Custom-Scripts/SEA-uninstall/aws-sea-cleanup.py
@@ -45,7 +45,8 @@ def get_accounts():
     paginator = organizations.get_paginator('list_accounts')
     page_iterator = paginator.paginate()
     for aws_accounts in page_iterator:
-        tmp = map(lambda x: [x["Id"], x["Name"]], aws_accounts["Accounts"])
+        active_accounts = list(filter(lambda x: (x['Status'] == "ACTIVE"), aws_accounts["Accounts"]))
+        tmp = map(lambda x: [x["Id"], x["Name"]], active_accounts)
     
         print(tabulate(list(tmp), headers=["Id", "Name"]))
         


### PR DESCRIPTION
When selecting Organization accounts to be included in the SEA Uninstall
process, those in the SUSPENDED or PENDING_CLOSURE state are included.
This leads to a failure whereby the SEA IAM role cannot be assumed for
these accounts. This change filters all accounts not in the ACTIVE
state.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
