### PR TITLE
allow adding iam conditions when creating an iam policy

### DIFF
--- a/src/deployments/cdk/src/common/iam-assets.ts
+++ b/src/deployments/cdk/src/common/iam-assets.ts
@@ -59,6 +59,7 @@ export class IamAssets extends cdk.Construct {
             effect: statement.Effect === 'Allow' ? iam.Effect.ALLOW : iam.Effect.DENY,
             actions: typeof statement.Action === 'string' ? [statement.Action] : statement.Action,
             resources: typeof statement.Resource === 'string' ? [statement.Resource] : statement.Resource,
+            conditions: statement.Condition,
           }),
         );
       }


### PR DESCRIPTION
When creating a new IAM policy, any IAM condition blocks in the policy are dropped by the accelerator. Fixes #980 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
