### PR TITLE
fix for issue with ALB forwarder when no HOSTS defined

### DIFF
--- a/src/deployments/runtime/src/alb-to-alb-target/alb-target-record-monitor.ts
+++ b/src/deployments/runtime/src/alb-to-alb-target/alb-target-record-monitor.ts
@@ -100,7 +100,7 @@ const createListenerRule = async (
     ruleParams.Conditions.push(pathConfig);
   }
 
-  if (hosts.length > 0) {
+  if (hosts?.length > 0) {
     const hostConfig = {
       Field: 'host-header',
       Values: hosts,
@@ -131,7 +131,7 @@ const updateListenerRule = async (ruleArn: string, paths: string[], hosts: strin
     ruleParams?.Conditions?.push(pathConfig);
   }
 
-  if (hosts.length > 0) {
+  if (hosts?.length > 0) {
     const hostConfig = {
       Field: 'host-header',
       Values: hosts,


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This fixes an issue with the ALB Forwarder when no *hosts* value is specified. From the docs, " `paths` and `hosts` are both optional". The lambda processor function fails with a .length on an undefined object. This pull requests adds a simple check to that condition statement.