### PR TITLE
fix: reduce concurrency on the Store Outputs phase

### DIFF
--- a/src/core/cdk/src/tasks/store-outputs-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-task.ts
@@ -47,7 +47,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 50,
+      maxConcurrency: 10,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',

--- a/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
@@ -59,7 +59,7 @@ export class StoreOutputsToSSMTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs To SSM`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 50,
+      maxConcurrency: 10,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This reduces the concurrency of the Store Outputs Phase which invokes additional step functions and Lambdas. This will fix customers with > 40 AWS Accounts seeing the following error:
```
{
	"error": "Lambda.TooManyRequestsException",
	"cause": "Rate Exceeded. (Service: Lambda, Status Code: 429, Request ID: ...)"
}
```