### PR TITLE
(addon): OpenSearch SIEM added CW Alarms

### DIFF
--- a/reference-artifacts/Add-ons/opensiem/README.md
+++ b/reference-artifacts/Add-ons/opensiem/README.md
@@ -551,9 +551,9 @@ The following AWS resources are retained when deleting the solution:
 - Updated the CDK version to v2.40.0
 - Updated the OpenSearch cluster with the latest version 1.3 (will cause a Blue/Green Deployment)
 - Updated the OpenSearch cluster to use GP3 for the EBS volume type (will cause a Blue/Green Deployment)
-- Added 14 CloudWatch Alarms to monitor the OpenSearch cluster base on the recommendations [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html)
+- Added 14 CloudWatch Alarms to monitor the OpenSearch cluster based on the recommendations [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html)
 - Reduced the Lambda Processor memory to 512MB and changed timeout to 2 minutes
 - Added a SNS queue to send alerts to registered emails. 
 - New configurations:
   - "alertNotificationEmails": ["user@email.com"]  CloudWatch Alarm will send notifications to emails listed here
-  - "enableLambdaInsights": true Will enable CloudWatch Lambda Insights. This brings visbility into memory usage to have data to fine tune the Processor Lambda.
+  - "enableLambdaInsights": true Will enable CloudWatch Lambda Insights. This brings visibility into memory usage to have data to fine tune the Processor Lambda.

--- a/reference-artifacts/Add-ons/opensiem/README.md
+++ b/reference-artifacts/Add-ons/opensiem/README.md
@@ -543,3 +543,17 @@ The following AWS resources are retained when deleting the solution:
 2. In the operations account
    1. navigate to S3, open the S3 bucket prefixed with **opensearchsiemstack-**, and delete all the objects inside
    1. navigate to CloudFormation and delete the **OpenSearchSiemStack** stack
+
+
+## 11. Updates
+
+### September 2022
+- Updated the CDK version to v2.40.0
+- Updated the OpenSearch cluster with the latest version 1.3 (will cause a Blue/Green Deployment)
+- Updated the OpenSearch cluster to use GP3 for the EBS volume type (will cause a Blue/Green Deployment)
+- Added 14 CloudWatch Alarms to monitor the OpenSearch cluster base on the recommendations [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html)
+- Reduced the Lambda Processor memory to 512MB and changed timeout to 2 minutes
+- Added a SNS queue to send alerts to registered emails. 
+- New configurations:
+  - "alertNotificationEmails": ["user@email.com"]  CloudWatch Alarm will send notifications to emails listed here
+  - "enableLambdaInsights": true Will enable CloudWatch Lambda Insights. This brings visbility into memory usage to have data to fine tune the Processor Lambda.

--- a/reference-artifacts/Add-ons/opensiem/SiemConfig.json
+++ b/reference-artifacts/Add-ons/opensiem/SiemConfig.json
@@ -54,5 +54,7 @@
     "s3NotificationTopicNameOrExistingArn": "----- REPLACE -----",
     "enableLambdaSubscription": false,
     "organizationId": "----- REPLACE -----",
+    "enableLambdaInsights": false,
+    "alertNotificationEmails": [""],
     "siemVersion": "v2.6.1a"
 }

--- a/reference-artifacts/Add-ons/opensiem/lib/open-search.ts
+++ b/reference-artifacts/Add-ons/opensiem/lib/open-search.ts
@@ -98,7 +98,7 @@ export class OpenSearchDomain extends Construct {
     });
 
     this.resource = new opensearch.CfnDomain(this, 'Domain', {
-      engineVersion: 'OpenSearch_1.1',
+      engineVersion: 'OpenSearch_1.3',
       domainName,
       clusterConfig: {
         dedicatedMasterEnabled: true,
@@ -117,7 +117,7 @@ export class OpenSearchDomain extends Construct {
       ebsOptions: {
         ebsEnabled: true,
         volumeSize,
-        volumeType: 'gp2',
+        volumeType: 'gp3',
       },
       advancedSecurityOptions: {
         internalUserDatabaseEnabled: false,

--- a/reference-artifacts/Add-ons/opensiem/lib/siem-alerts.ts
+++ b/reference-artifacts/Add-ons/opensiem/lib/siem-alerts.ts
@@ -1,0 +1,353 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as cw from 'aws-cdk-lib/aws-cloudwatch';
+import * as cwActions from 'aws-cdk-lib/aws-cloudwatch-actions';
+
+export interface AlertsProps {
+  alertTopic: sns.ITopic;
+  clusterDomainName: string;
+}
+
+export class Alerts extends Construct {
+  constructor(scope: Construct, id: string, private readonly props: AlertsProps) {
+    super(scope, id);
+
+    const { alertTopic, clusterDomainName } = props;
+
+    //
+    // CloudWatch Alarm - ClusterStatus.red
+    //
+    const clusterStatusRedAlarm = new cw.Alarm(this, 'ClusterStatusRed', {
+      alarmName: 'OpenSearchSIEM-ClusterStatus.red >= 1',
+      alarmDescription: 'Email when ClusterStatus.red >=1, 1 time within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ClusterStatus.red',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusRedAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusRedAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - ClusterStatus.yellow
+    //
+    const clusterStatusYellowAlarm = new cw.Alarm(this, 'ClusterStatusYellow', {
+      alarmName: 'OpenSearchSIEM-ClusterStatus.yellow >= 1',
+      alarmDescription: 'Email when ClusterStatus.yellow >=1, 1 time within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ClusterStatus.yellow',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusYellowAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusYellowAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - FreeStorageSpace
+    //
+    const clusterStatusFreeStorageSpaceAlarm = new cw.Alarm(this, 'FreeStorageSpace', {
+      alarmName: 'OpenSearchSIEM-FreeStorageSpace <= 20480',
+      alarmDescription: 'Email when FreeStorageSpace <= 20480, 1 time within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 20480,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'FreeStorageSpace',
+        statistic: cw.Statistic.MINIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusFreeStorageSpaceAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusFreeStorageSpaceAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - ClusterIndexWritesBlocked
+    //
+    const clusterStatusClusterIndexWritesBlockedAlarm = new cw.Alarm(this, 'ClusterIndexWritesBlocked', {
+      alarmName: 'OpenSearchSIEM-ClusterIndexWritesBlocked >= 1',
+      alarmDescription: 'Email when ClusterIndexWritesBlocked >= 1, 1 time within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ClusterIndexWritesBlocked',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(300),
+      }),
+    });
+    clusterStatusClusterIndexWritesBlockedAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusClusterIndexWritesBlockedAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - AutomatedSnapshotFailure
+    //
+    const clusterStatusClusterAutomatedSnapshotFailureAlarm = new cw.Alarm(this, 'AutomatedSnapshotFailure', {
+      alarmName: 'OpenSearchSIEM-AutomatedSnapshotFailure >= 1',
+      alarmDescription: 'Email when AutomatedSnapshotFailure >= 1, 1 time within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'AutomatedSnapshotFailure',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusClusterAutomatedSnapshotFailureAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusClusterAutomatedSnapshotFailureAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - CPUUtilization
+    //
+    const clusterStatusClusterCPUUtilizationAlarm = new cw.Alarm(this, 'CPUUtilization', {
+      alarmName: 'OpenSearchSIEM-CPUUtilization >= 80',
+      alarmDescription: 'Email when CPUUtilization >= 80, 3 times within 15 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 80,
+      evaluationPeriods: 3,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'CPUUtilization',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(900),
+      }),
+    });
+    clusterStatusClusterCPUUtilizationAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusClusterCPUUtilizationAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - JVMMemoryPressure
+    //
+    const clusterStatusJVMMemoryPressureAlarm = new cw.Alarm(this, 'JVMMemoryPressure', {
+      alarmName: 'OpenSearchSIEM-JVMMemoryPressure >= 80',
+      alarmDescription: 'Email when JVMMemoryPressure >= 80, 3 times within 5 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 80,
+      evaluationPeriods: 3,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'JVMMemoryPressure',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(300),
+      }),
+    });
+    clusterStatusJVMMemoryPressureAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusJVMMemoryPressureAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - MasterCPUUtilization
+    //
+    const clusterStatusMasterCPUUtilizationAlarm = new cw.Alarm(this, 'MasterCPUUtilization', {
+      alarmName: 'OpenSearchSIEM-MasterCPUUtilization >= 50',
+      alarmDescription: 'Email when MasterCPUUtilization >= 50, 3 times within 5 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 50,
+      evaluationPeriods: 3,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'MasterCPUUtilization',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(300),
+      }),
+    });
+    clusterStatusMasterCPUUtilizationAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusMasterCPUUtilizationAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - MasterJVMMemoryPressure
+    //
+    const clusterStatusMasterJVMMemoryPressureAlarm = new cw.Alarm(this, 'MasterJVMMemoryPressure', {
+      alarmName: 'OpenSearchSIEM-MasterJVMMemoryPressure >= 80',
+      alarmDescription: 'Email when MasterJVMMemoryPressure >= 80, 1 times within 15 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 80,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'MasterJVMMemoryPressure',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(900),
+      }),
+    });
+    clusterStatusMasterJVMMemoryPressureAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusMasterJVMMemoryPressureAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - Shards.active
+    //
+    const clusterStatusShardsActiveAlarm = new cw.Alarm(this, 'ShardsActive', {
+      alarmName: 'OpenSearchSIEM-ShardsActive >= 30000',
+      alarmDescription: 'Email when ShardsActive >= 30000, 1 times within 1 minutes',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 30000,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'Shards.active',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusShardsActiveAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusShardsActiveAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - MasterReachableFromNode
+    //
+    const clusterStatusMasterReachableFromNodeAlarm = new cw.Alarm(this, 'MasterReachableFromNode', {
+      alarmName: 'OpenSearchSIEM-MasterReachableFromNode < 1',
+      alarmDescription: 'Email when MasterReachableFromNode < 1, 1 times within 1 day',
+      comparisonOperator: cw.ComparisonOperator.LESS_THAN_THRESHOLD,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'MasterReachableFromNode',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.days(1),
+      }),
+    });
+    clusterStatusMasterReachableFromNodeAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusMasterReachableFromNodeAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - ThreadpoolWriteQueue
+    //
+    const clusterStatusThreadpoolWriteQueueAlarm = new cw.Alarm(this, 'ThreadpoolWriteQueue', {
+      alarmName: 'OpenSearchSIEM-ThreadpoolWriteQueue average >= 100',
+      alarmDescription: 'Email when ThreadpoolWriteQueue >= 100, 1 times within 1 minute',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 100,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ThreadpoolWriteQueue',
+        statistic: cw.Statistic.AVERAGE,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusThreadpoolWriteQueueAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusThreadpoolWriteQueueAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - ThreadpoolSearchQueue
+    //
+    const clusterStatusThreadpoolSearchQueueAlarm = new cw.Alarm(this, 'ThreadpoolSearchQueue', {
+      alarmName: 'OpenSearchSIEM-ThreadpoolSearchQueue average >= 500',
+      alarmDescription: 'Email when average ThreadpoolSearchQueue >= 500, 1 times within 1 minute',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 500,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ThreadpoolSearchQueue',
+        statistic: cw.Statistic.AVERAGE,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusThreadpoolSearchQueueAlarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusThreadpoolSearchQueueAlarm.addOkAction(new cwActions.SnsAction(alertTopic));
+
+    //
+    // CloudWatch Alarm - ThreadpoolSearchQueue5000
+    //
+    const clusterStatusThreadpoolSearchQueue5000Alarm = new cw.Alarm(this, 'ThreadpoolSearchQueue5000', {
+      alarmName: 'OpenSearchSIEM-ThreadpoolSearchQueue >= 5000',
+      alarmDescription: 'Email when ThreadpoolSearchQueue >= 5000, 1 times within 1 minute',
+      comparisonOperator: cw.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      threshold: 5000,
+      evaluationPeriods: 1,
+      metric: new cw.Metric({
+        namespace: 'AWS/ES',
+        metricName: 'ThreadpoolSearchQueue',
+        statistic: cw.Statistic.MAXIMUM,
+        dimensionsMap: {
+          ClientId: cdk.Stack.of(this).account,
+          DomainName: clusterDomainName,
+        },
+        period: cdk.Duration.seconds(60),
+      }),
+    });
+    clusterStatusThreadpoolSearchQueue5000Alarm.addAlarmAction(new cwActions.SnsAction(alertTopic));
+    clusterStatusThreadpoolSearchQueue5000Alarm.addOkAction(new cwActions.SnsAction(alertTopic));
+  }
+}

--- a/reference-artifacts/Add-ons/opensiem/lib/siem-cognito.ts
+++ b/reference-artifacts/Add-ons/opensiem/lib/siem-cognito.ts
@@ -103,7 +103,11 @@ export class CognitoUserPool extends Construct {
 
     const { userPoolName, usernameAttributes } = props;
 
-    const externalId: string = Math.random().toString(11).slice(2);
+    let externalId: string = this.node.tryGetContext('externalId');
+
+    if (!externalId) {
+      externalId = Math.random().toString(11).slice(2);
+    }
 
     const snsRole = new iam.Role(this, 'MfaSnsRole', {
       assumedBy: new iam.ServicePrincipal('cognito-idp.amazonaws.com'),

--- a/reference-artifacts/Add-ons/opensiem/lib/siem-config.ts
+++ b/reference-artifacts/Add-ons/opensiem/lib/siem-config.ts
@@ -56,6 +56,8 @@ export interface SiemConfig {
   enableLambdaSubscription: boolean;
   s3NotificationTopicNameOrExistingArn: string;
   organizationId: string;
+  alertNotificationEmails: string[];
+  enableLambdaInsights: boolean;
 }
 
 export async function loadSiemConfig(): Promise<SiemConfig> {

--- a/reference-artifacts/Add-ons/opensiem/package-lock.json
+++ b/reference-artifacts/Add-ons/opensiem/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-asea-opensearch-siem",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.17.0",
+        "aws-cdk-lib": "2.40.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.16"
       },
@@ -20,7 +20,7 @@
         "@types/node": "10.17.27",
         "@typescript-eslint/eslint-plugin": "4.22.0",
         "@typescript-eslint/parser": "4.22.0",
-        "aws-cdk": "2.17.0",
+        "aws-cdk": "2.40.0",
         "eslint": "7.25.0",
         "eslint-config-prettier": "8.3.0",
         "eslint-plugin-deprecation": "1.2.0",
@@ -1632,9 +1632,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.17.0.tgz",
-      "integrity": "sha512-gRPPpTONOjtQ40A8sc2SzXPGDzFlVbSPPts1pjOx4VBJ2S91A0ON3Fkby+XX/Xqdo1GITTWAk5Va4PnoYyUhmA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.40.0.tgz",
+      "integrity": "sha512-oHacGkLFDELwhpJsZSAhFHWDxIeZW3DgKkwiXlNO81JxNfjcHgPR2rsbh/Gz+n4ErAEzOV6WfuWVMe68zv+iPg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -1647,9 +1647,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.17.0.tgz",
-      "integrity": "sha512-bga2HptbGx3rMdSkIKxBS13miogj/DHB2VPfQZAoKoCOAanOot+M3mHhYqe5aNdxhrppaRjG2eid2p1/MvRnvg==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.40.0.tgz",
+      "integrity": "sha512-AHDPU4I+WP3x+8W2TcSNPDhiA1wmvYkhaz5VjsQ9bqrnu2tJhcQaYkJCUu49MOVfUDpWYp9DnZIL0Yirlp5X6w==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1666,10 +1666,10 @@
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1734,7 +1734,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.9",
+      "version": "4.2.10",
       "inBundle": true,
       "license": "ISC"
     },
@@ -1758,7 +1758,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.0",
+      "version": "1.4.1",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1796,7 +1796,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.3.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -7306,7 +7306,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -9967,27 +9966,27 @@
       "dev": true
     },
     "aws-cdk": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.17.0.tgz",
-      "integrity": "sha512-gRPPpTONOjtQ40A8sc2SzXPGDzFlVbSPPts1pjOx4VBJ2S91A0ON3Fkby+XX/Xqdo1GITTWAk5Va4PnoYyUhmA==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.40.0.tgz",
+      "integrity": "sha512-oHacGkLFDELwhpJsZSAhFHWDxIeZW3DgKkwiXlNO81JxNfjcHgPR2rsbh/Gz+n4ErAEzOV6WfuWVMe68zv+iPg==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.17.0.tgz",
-      "integrity": "sha512-bga2HptbGx3rMdSkIKxBS13miogj/DHB2VPfQZAoKoCOAanOot+M3mHhYqe5aNdxhrppaRjG2eid2p1/MvRnvg==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.40.0.tgz",
+      "integrity": "sha512-AHDPU4I+WP3x+8W2TcSNPDhiA1wmvYkhaz5VjsQ9bqrnu2tJhcQaYkJCUu49MOVfUDpWYp9DnZIL0Yirlp5X6w==",
       "requires": {
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.0",
-        "jsonschema": "^1.4.0",
+        "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.1.1",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -10030,7 +10029,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.9",
+          "version": "4.2.10",
           "bundled": true
         },
         "ignore": {
@@ -10046,7 +10045,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.0",
+          "version": "1.4.1",
           "bundled": true
         },
         "lru-cache": {
@@ -10068,7 +10067,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.3.5",
+          "version": "7.3.7",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -14248,8 +14247,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/reference-artifacts/Add-ons/opensiem/package.json
+++ b/reference-artifacts/Add-ons/opensiem/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.10",
     "@types/node": "10.17.27",
-    "aws-cdk": "2.17.0",
+    "aws-cdk": "2.40.0",
     "jest": "^26.4.2",
     "ts-jest": "^26.2.0",
     "ts-node": "^9.0.0",
@@ -37,7 +37,7 @@
     "eslint-plugin-unicorn": "31.0.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.17.0",
+    "aws-cdk-lib": "2.40.0",
     "constructs": "^10.0.0",    
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


###  Updates
- Updated the CDK version to v2.40.0
- Updated the OpenSearch cluster with the latest version 1.3 (will cause a Blue/Green Deployment)
- Updated the OpenSearch cluster to use GP3 for the EBS volume type (will cause a Blue/Green Deployment)
- Added 14 CloudWatch Alarms to monitor the OpenSearch cluster based on the recommendations [here](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html)
- Reduced the Lambda Processor memory to 512MB and changed timeout to 2 minutes
- Added a SNS queue to send alerts to registered emails. 
- New configurations:
  - "alertNotificationEmails": ["user@email.com"]  CloudWatch Alarm will send notifications to emails listed here
  - "enableLambdaInsights": true Will enable CloudWatch Lambda Insights. This brings visibility into memory usage to have data to fine tune the Processor Lambda.