### PR TITLE
(enhancement): Frequency for updated findings for GuardDuty

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -61,6 +61,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
@@ -74,6 +74,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
@@ -61,6 +61,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
@@ -56,6 +56,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -61,6 +61,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -61,6 +61,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [],

--- a/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
@@ -73,6 +73,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "access-analyzer": true,
       "config-excl-regions": [

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-CT-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-CT-example.json
@@ -37,6 +37,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "cwl-access-level": "full",
       "access-analyzer": true,

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
@@ -35,6 +35,7 @@
       "guardduty-excl-regions": [],
       "guardduty-s3": true,
       "guardduty-s3-excl-regions": [],
+      "guardduty-frequency": "FIFTEEN_MINUTES",
       "cwl": true,
       "cwl-access-level": "full",
       "access-analyzer": true,

--- a/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
+++ b/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
@@ -23,6 +23,12 @@ import { GuardDutyAdminSetup } from '@aws-accelerator/custom-resource-guardduty-
 import { IamRoleOutputFinder } from '@aws-accelerator/common-outputs/src/iam-role';
 import { StackOutput } from '@aws-accelerator/common-outputs/src/stack-output';
 
+export enum GuardDutyFrequency {
+  FIFTEEN_MINUTES = 'FIFTEEN_MINUTES',
+  ONE_HOUR = 'ONE_HOUR',
+  SIX_HOURS = 'SIX_HOURS',
+}
+
 export interface GuardDutyStepProps {
   accountStacks: AccountStacks;
   config: AcceleratorConfig;
@@ -110,12 +116,14 @@ export async function step2(props: GuardDutyStepProps) {
   }));
   const centralServiceConfig = props.config['global-options']['central-security-services'];
   const s3ProtectionExclRegions = centralServiceConfig['guardduty-s3-excl-regions'] || [];
+  const frequency = await getFrequency(props.config);
   regions?.map(region => {
     const masterAccountStack = props.accountStacks.getOrCreateAccountStack(masterAccountKey, region);
     new GuardDutyAdminSetup(masterAccountStack, 'GuardDutyAdminSetup', {
       memberAccounts: accountDetails,
       roleArn: adminSetupRoleOutput.roleArn,
       s3Protection: centralServiceConfig['guardduty-s3'] && !s3ProtectionExclRegions.includes(region),
+      frequency,
     });
   });
 }
@@ -196,4 +204,17 @@ export async function getValidRegions(config: AcceleratorConfig) {
   const excl = config['global-options']['central-security-services']['guardduty-excl-regions'];
   const validRegions = regions.filter(x => !excl?.includes(x));
   return validRegions;
+}
+
+export async function getFrequency(config: AcceleratorConfig) {
+  const frequency = config['global-options']['central-security-services']['guardduty-frequency'];
+  if (frequency === GuardDutyFrequency.SIX_HOURS) {
+    return GuardDutyFrequency.SIX_HOURS;
+  } else if (frequency === GuardDutyFrequency.ONE_HOUR) {
+    return GuardDutyFrequency.ONE_HOUR;
+  } else if (frequency === GuardDutyFrequency.FIFTEEN_MINUTES) {
+    return GuardDutyFrequency.FIFTEEN_MINUTES;
+  } else {
+    return GuardDutyFrequency.SIX_HOURS;
+  }
 }

--- a/src/lib/config-i18n/src/en.ts
+++ b/src/lib/config-i18n/src/en.ts
@@ -2807,6 +2807,11 @@ translate(c.CentralServicesConfigType, {
       title: 'GuardDuty S3 Protection Exclusion Regions',
       description: 'List of excluded regions from Guardduty S3 protection. [SECURITY]',
     },
+    'guardduty-frequency': {
+      title: 'Update Frequency for Policy Findings',
+      description:
+        'The schedule GuardDuty uses to publish updates to policy findings. Supported values are: FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS. [SECURITY]',
+    },
     'access-analyzer': {
       title: '',
       description:

--- a/src/lib/config-i18n/src/fr.ts
+++ b/src/lib/config-i18n/src/fr.ts
@@ -2609,6 +2609,10 @@ translate(c.CentralServicesConfigType, {
       title: '',
       description: '',
     },
+    'guardduty-frequency': {
+      title: '',
+      description: '',
+    },
     'access-analyzer': {
       title: '',
       description: '',

--- a/src/lib/config/src/config.v2.ts
+++ b/src/lib/config/src/config.v2.ts
@@ -907,6 +907,7 @@ export const CentralServicesConfigType = t.interface({
   'guardduty-excl-regions': t.optional(t.array(t.nonEmptyString)),
   'guardduty-s3': t.defaulted(t.boolean, false),
   'guardduty-s3-excl-regions': t.optional(t.array(t.nonEmptyString)),
+  'guardduty-frequency': t.optional(t.nonEmptyString),
   'access-analyzer': t.defaulted(t.boolean, false),
   cwl: t.defaulted(t.boolean, false),
   'cwl-access-level': t.optional(t.nonEmptyString),

--- a/src/lib/custom-resources/cdk-guardduty-admin-setup/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-guardduty-admin-setup/cdk/index.ts
@@ -15,6 +15,7 @@ import * as path from 'path';
 import * as cdk from '@aws-cdk/core';
 import * as iam from '@aws-cdk/aws-iam';
 import * as lambda from '@aws-cdk/aws-lambda';
+import { GuardDutyFrequency } from '@aws-accelerator/custom-resource-guardduty-admin-setup-runtime';
 
 const resourceType = 'Custom::GuardDutyAdminSetup';
 
@@ -27,6 +28,7 @@ export interface GuardDutyAdminSetupProps {
   memberAccounts: AccountDetail[];
   roleArn: string;
   s3Protection: boolean;
+  frequency: GuardDutyFrequency;
 }
 
 /**
@@ -43,6 +45,7 @@ export class GuardDutyAdminSetup extends cdk.Construct {
     const handlerProperties = {
       memberAccounts: props.memberAccounts,
       s3Protection: props.s3Protection,
+      frequency: props.frequency,
     };
 
     const adminSetup = this.lambdaFunction(props.roleArn);


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This pull requests implements a new configuration value `"guardduty-frequency"` with the following possible values: `FIFTEEN_MINUTES, ONE_HOUR, SIX_HOURS`

By default, the Frequency for updated findings for GuardDuty is set at the default, SIX_HOURS. 


Here's an example of the result with the following config:
```
"guardduty-frequency": "ONE_HOUR",
```
![image](https://user-images.githubusercontent.com/41204211/190547077-9cba4f4d-e848-4a0e-bd8d-7c9b53182bef.png)
