### PR TITLE
(fix) Decrease max concurrency limit to 10

### DIFF
--- a/src/core/cdk/src/tasks/store-outputs-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-task.ts
@@ -47,7 +47,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 50,
+      maxConcurrency: 10,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',
@@ -120,7 +120,7 @@ export class StoreOutputsTask extends sfn.StateMachineFragment {
     const storeAccountRegionOutputs = new sfn.Map(this, `Store Account Region Outputs`, {
       itemsPath: `$.regions`,
       resultPath: 'DISCARD',
-      maxConcurrency: 20,
+      maxConcurrency: 10,
       parameters: {
         'account.$': '$.account',
         'region.$': '$$.Map.Item.Value',

--- a/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
+++ b/src/core/cdk/src/tasks/store-outputs-to-ssm-task.ts
@@ -59,7 +59,7 @@ export class StoreOutputsToSSMTask extends sfn.StateMachineFragment {
     const storeAccountOutputs = new sfn.Map(this, `Store Account Outputs To SSM`, {
       itemsPath: `$.accounts`,
       resultPath: 'DISCARD',
-      maxConcurrency: 50,
+      maxConcurrency: 10,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',
         'regions.$': '$.regions',
@@ -148,7 +148,7 @@ export class StoreOutputsToSSMTask extends sfn.StateMachineFragment {
     const storeAccountRegionOutputs = new sfn.Map(this, `Store Account Region Outputs To SSM`, {
       itemsPath: `$.regions`,
       resultPath: 'DISCARD',
-      maxConcurrency: 20,
+      maxConcurrency: 10,
       parameters: {
         'account.$': '$.account',
         'region.$': '$$.Map.Item.Value',


### PR DESCRIPTION
Extension of PR:  #1047

Decreasing maxconcurrency  for StoreOutputTasks and StoreOutputsToSSMTasks based on newer default Lambda limits.

This reduces the concurrency of the Store Outputs Phase which invokes additional step functions and Lambdas. This will fix customers with > 40 AWS Accounts seeing the following error:

{
	"error": "Lambda.TooManyRequestsException",
	"cause": "Rate Exceeded. (Service: Lambda, Status Code: 429, Request ID: ...)"
}
