### PR TITLE
(fix): update alb ip monitor dns lookup check

### DIFF
--- a/src/deployments/runtime/src/alb-to-alb-target/alb-ip-monitor.ts
+++ b/src/deployments/runtime/src/alb-to-alb-target/alb-ip-monitor.ts
@@ -90,14 +90,15 @@ const dnslookup = async (host: string): Promise<string[]> => {
     dns.lookup(host, { all: true, family: 4 }, (err, addresses) => {
       if (err) {
         reject(err);
+      } else {
+        resolve(
+          addresses
+            .map(item => {
+              return item.address;
+            })
+            .sort(),
+        );
       }
-      resolve(
-        addresses
-          .map(item => {
-            return item.address;
-          })
-          .sort(),
-      );
     });
   });
 };
@@ -127,7 +128,12 @@ export const handler = async (_event: any, _context: any) => {
   for (const targetGroupRecord of targetGroupRecords) {
     try {
       // Get Hostname Lookup
-      targetGroupRecord.dnsLookupIps = (await dnslookup(targetGroupRecord.targetAlbDnsName)) ?? [];
+      targetGroupRecord.dnsLookupIps = [];
+      try {
+        targetGroupRecord.dnsLookupIps = await dnslookup(targetGroupRecord.targetAlbDnsName);
+      } catch (err) {
+        console.log(err);
+      }
       // Get Ip Addresses to add to current IP List
       targetGroupRecord.ipAddList =
         targetGroupRecord.dnsLookupIps?.filter(ip => {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Proper error handling for when a DNS entry doesn't resolve; it will no longer crash out, but continue processing other records.

![image](https://user-images.githubusercontent.com/41204211/196843619-eab7be34-c38d-46ae-acbe-976ecb5d2781.png)

Note the console.log of the failed DNS entry, but how it continues to process.