### PR TITLE
(enhancement): Adjust the Throttle Backoff setting delayFirstAttempt to false

### DIFF
--- a/reference-artifacts/Add-ons/opensiem/lambdas/common/src/backoff.ts
+++ b/reference-artifacts/Add-ons/opensiem/lambdas/common/src/backoff.ts
@@ -37,7 +37,7 @@ export function throttlingBackOff<T>(
 
   return backOff(request, {
     startingDelay,
-    delayFirstAttempt: true,
+    delayFirstAttempt: false,
     jitter: 'full',
     retry: isThrottlingError,
     ...options,

--- a/src/lib/common/src/aws/backoff.ts
+++ b/src/lib/common/src/aws/backoff.ts
@@ -37,7 +37,7 @@ export function throttlingBackOff<T>(
 
   return backOff(request, {
     startingDelay,
-    delayFirstAttempt: true,
+    delayFirstAttempt: false,
     jitter: 'full',
     retry: isThrottlingError,
     ...options,

--- a/src/lib/custom-resources/cdk-cfn-utils/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-cfn-utils/cdk/index.ts
@@ -39,7 +39,7 @@ export function throttlingBackOff<T>(
 
   return backOff(request, {
     startingDelay,
-    delayFirstAttempt: true,
+    delayFirstAttempt: false,
     jitter: 'full',
     retry: isThrottlingError,
     ...options,


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

When delayFirstAttempt is set to true, a random wait is added for all calls. This has increased State Machine processing time and 'Add Tags to Shared Resources' may now timeout. This PR switches the *delayFirstAttemp* to false.

Below are the AddTagsToSharedResource processing times:

v1.5.3:
![image](https://user-images.githubusercontent.com/41204211/197003403-5a13ff47-0497-4098-a7dc-6ba6dcefeddf.png)


v1.5.4:
![image](https://user-images.githubusercontent.com/41204211/197003341-97eaf0b5-583e-4f0d-8a25-4acb0c105784.png)


This PR:
![image](https://user-images.githubusercontent.com/41204211/197003260-464a7d48-b3b4-494d-9dd5-94415ba4e41e.png)
