### PR TITLE
Add logs:TagLogGroup permission to the log group role 

### DIFF
--- a/src/deployments/cdk/src/deployments/iam/log-group-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/log-group-role.ts
@@ -46,7 +46,7 @@ async function createRole(stack: AccountStack) {
         'logs:DeleteRetentionPolicy',
         'logs:DescribeLogGroups',
         'logs:AssociateKmsKey',
-        'logs:TagLogGroup'
+        'logs:TagLogGroup',
       ],
       resources: ['*'],
     }),

--- a/src/deployments/cdk/src/deployments/iam/log-group-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/log-group-role.ts
@@ -46,6 +46,7 @@ async function createRole(stack: AccountStack) {
         'logs:DeleteRetentionPolicy',
         'logs:DescribeLogGroups',
         'logs:AssociateKmsKey',
+        'logs:TagLogGroup'
       ],
       resources: ['*'],
     }),


### PR DESCRIPTION
This role is used by the custom resource to create log groups. Something seems to have changed in the CDK log implementation or in the CW logs creation which is now requiring this IAM action to be in the policy. 

See #1079 for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
