### PR TITLE
Fix/issue 1099 - AWS Config rule IAM Password Policy boolean values

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
@@ -765,10 +765,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -768,10 +768,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
@@ -780,10 +780,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
@@ -768,10 +768,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
@@ -763,10 +763,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
@@ -765,10 +765,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -768,10 +768,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -772,10 +772,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {

--- a/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
@@ -828,10 +828,10 @@
             "MaxPasswordAge": "90",
             "MinimumPasswordLength": "14",
             "PasswordReusePrevention": "24",
-            "RequireLowercaseCharacters": "TRUE",
-            "RequireNumbers": "TRUE",
-            "RequireSymbols": "TRUE",
-            "RequireUppercaseCharacters": "TRUE"
+            "RequireLowercaseCharacters": "true",
+            "RequireNumbers": "true",
+            "RequireSymbols": "true",
+            "RequireUppercaseCharacters": "true"
           }
         },
         {


### PR DESCRIPTION
Fix the issue of the AWS Config rule IAM Password Policy as described in Issue #1099 by updating the boolean "TRUE" values to lowercase "true" in each of the applicable SAMPLE_CONFIGS files. 

For existing environments the changes can be applied to the current config and run the state machine with the execution input of {"scope":"GLOBAL-OPTIONS","mode":"APPLY"}. 
