### PR TITLE
Fix for Issue# 1060: Cannot enforce an AWS Backup Policy

### DIFF
--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part0-CoreOUs.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part0-CoreOUs.json
@@ -102,9 +102,12 @@
       "Action": [
         "acm:DeleteCert*",
         "acm:ExportCert*",
+        "acm:AddTagsToCert*",
         "acm:RemoveTagsFromCert*",
         "elasticloadbalancing:DeleteLoadBal*",
-        "elasticloadbalancing:DeleteTargetG*"
+        "elasticloadbalancing:DeleteTargetG*",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part0-WkldOUs.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part0-WkldOUs.json
@@ -102,9 +102,12 @@
       "Action": [
         "acm:DeleteCert*",
         "acm:ExportCert*",
+        "acm:AddTagsToCert*",
         "acm:RemoveTagsFromCert*",
         "elasticloadbalancing:DeleteLoadBal*",
-        "elasticloadbalancing:DeleteTargetG*"
+        "elasticloadbalancing:DeleteTargetG*",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -8,7 +8,9 @@
         "ec2:DeleteSecurityGroup",
         "ec2:RevokeSecurityGroup*",
         "ec2:AuthorizeSecurityGroup*",
-        "ec2:CreateSecurityGroup"
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
       ],
       "Resource": "*",
       "Condition": {
@@ -34,7 +36,9 @@
         "iam:ListRoles",
         "iam:GetInstanceProfile",
         "iam:GetLoginProfile",
-        "iam:ListInstanceProfiles"
+        "iam:ListInstanceProfiles",
+        "iam:Tag*",
+        "iam:Untag*"
       ],
       "Resource": "*",
       "Condition": {
@@ -221,7 +225,9 @@
         "ec2:DeleteSubnet",
         "ec2:DeleteRoute",
         "ec2:DetachInternetGateway",
-        "ec2:DisassociateRouteTable"
+        "ec2:DisassociateRouteTable",
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -36,9 +36,7 @@
         "iam:ListRoles",
         "iam:GetInstanceProfile",
         "iam:GetLoginProfile",
-        "iam:ListInstanceProfiles",
-        "iam:Tag*",
-        "iam:Untag*"
+        "iam:ListInstanceProfiles"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Part1.json
@@ -9,7 +9,6 @@
         "ec2:RevokeSecurityGroup*",
         "ec2:AuthorizeSecurityGroup*",
         "ec2:CreateSecurityGroup",
-        "ec2:CreateTags",
         "ec2:DeleteTags"
       ],
       "Resource": "*",
@@ -224,7 +223,6 @@
         "ec2:DeleteRoute",
         "ec2:DetachInternetGateway",
         "ec2:DisassociateRouteTable",
-        "ec2:CreateTags",
         "ec2:DeleteTags"
       ],
       "Resource": "*",


### PR DESCRIPTION
This PR carries two fixes

1. Issue# 1060 - ASEA removes any backup policies attached to the OUs
2. The SCPs to protect ASEA resources based of a ResourceTag condition does not protect from the tag itself being removed

Resolves https://github.com/aws-samples/aws-secure-environment-accelerator/issues/1060