### PR TITLE
Exempt cfn stacksets service role from quarantine policy

### DIFF
--- a/src/lib/common/src/scp/index.ts
+++ b/src/lib/common/src/scp/index.ts
@@ -378,6 +378,7 @@ export class ServiceControlPolicy {
                 `arn:aws:iam::*:role/${props.organizationAdminRole || 'AWSCloudFormationStackSetExecutionRole'}`,
                 `arn:aws:iam::*:role/${props.acceleratorPrefix}*`,
                 'arn:aws:iam::*:role/aws*',
+                'arn:aws:iam::*:role/stacksets-exec*'
               ],
             },
           },


### PR DESCRIPTION
Add CFN Stacksets service role to quarantine policy, to allow management account Stacksets to be able to bootstrap new accounts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
