### PR TITLE
fix for #1111

### DIFF
--- a/src/deployments/cdk/src/deployments/vpc/step-2.ts
+++ b/src/deployments/cdk/src/deployments/vpc/step-2.ts
@@ -156,13 +156,14 @@ function createVpcFlowLog(props: {
     customFields,
   } = props;
   for (const [index, logDestination] of logDestinations.entries()) {
-    const flowLogs = new ec2.CfnFlowLog(scope, `FlowLog${vpcName}${logDestinationTypes[index]}`, {
-      deliverLogsPermissionArn: roleArn,
+    const logDestinationType = logDestinationTypes[index];
+    const flowLogs = new ec2.CfnFlowLog(scope, `FlowLog${vpcName}${logDestinationType}`, {
+      deliverLogsPermissionArn: logDestinationType == ec2.FlowLogDestinationType.CLOUD_WATCH_LOGS ? roleArn : undefined,
       resourceId: vpcId,
       resourceType: 'VPC',
       trafficType,
       logDestination,
-      logDestinationType: logDestinationTypes[index],
+      logDestinationType: logDestinationType,
     });
     flowLogs.addPropertyOverride('MaxAggregationInterval', aggregationInterval);
     if (customFields) {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This changes the parameters used when calling `new ec2.CfnFlowLog`. 

IMPORTANT: Every S3 VPC Flow Log configuration must first be deleted. It will be recreated after the State Machine executes. The fastest way is to use the ASEA-PipelineRole to the Shared Networking and Perimeter accounts (and Management ForSSO VPC), and to manually remove the S3 VPC Flow Log settings from every VPC.


To reproduce the issue, add the following VPC snippet to a Workload Account in the config.json
```
"vpc": [
    {
      "deploy": "local",
      "name": "Sandbox",
      "description": "This VPC is deployed locally in each Sandbox account and each account/VPC is deployed with the same identical CIDR range.  This VPC has no access to the rest of the Organizations networking and has direct internet access and does not use the perimeter ingress/egress services.",
      "cidr-src": "provided",
      "cidr": [
        {
          
          "value": "10.0.0.0/16"
        }
      ],
      "region": "ca-central-1",
      "use-central-endpoints": false,
      "flow-logs": "BOTH",
      "dns-resolver-logging": true,
      "igw": true,
      "subnets": [
        {
          "name": "Web",
          "share-to-ou-accounts": false,
          "share-to-specific-accounts": [],
          "definitions": [
            {
              "az": "a",
              "route-table": "SandboxVPC_IGW",
              "cidr": {
                "value": "10.0.1.0/20"
              }
            }
          ]
        }
      ],
      "gateway-endpoints": [],
      "route-tables": [],
      "security-groups": []
    }
  ]
```