### PR TITLE
fix for EventBridge notifications sent to SNS

### DIFF
--- a/src/deployments/cdk/src/deployments/defaults/shared.ts
+++ b/src/deployments/cdk/src/deployments/defaults/shared.ts
@@ -54,6 +54,8 @@ export function createDefaultS3Key(props: { accountStack: AccountStack; prefix: 
         new iam.ServicePrincipal('macie.amazonaws.com'),
         // Kinesis for usage in the log account
         new iam.ServicePrincipal('kinesis.amazonaws.com'),
+        // Events
+        new iam.ServicePrincipal('events.amazonaws.com'),
       ],
       resources: ['*'],
     }),

--- a/src/deployments/cdk/src/deployments/sns/step-1.ts
+++ b/src/deployments/cdk/src/deployments/sns/step-1.ts
@@ -258,17 +258,17 @@ function createSnsTopics(props: {
           topicName,
         });
 
-    // Allowing Publish from CloudWatch Service form any account
+    // Allowing Publish from CloudWatch Service from any account
     topic.grantPublish({
       grantPrincipal: new iam.ServicePrincipal('cloudwatch.amazonaws.com'),
     });
 
-    // Allowing Publish from Lambda Service form any account
+    // Allowing Publish from Lambda Service from any account
     topic.grantPublish({
       grantPrincipal: new iam.ServicePrincipal('lambda.amazonaws.com'),
     });
 
-    // Allowing Publish from Events Service form any account
+    // Allowing Publish from Events Service from any account
     topic.grantPublish({
       grantPrincipal: new iam.ServicePrincipal('events.amazonaws.com'),
     });

--- a/src/deployments/cdk/src/deployments/sns/step-1.ts
+++ b/src/deployments/cdk/src/deployments/sns/step-1.ts
@@ -268,6 +268,11 @@ function createSnsTopics(props: {
       grantPrincipal: new iam.ServicePrincipal('lambda.amazonaws.com'),
     });
 
+    // Allowing Publish from Events Service form any account
+    topic.grantPublish({
+      grantPrincipal: new iam.ServicePrincipal('events.amazonaws.com'),
+    });
+
     topic.addToResourcePolicy(
       new iam.PolicyStatement({
         principals: [new iam.AnyPrincipal()],


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

EventBridge needs KMS key policy permissions to the Rule Target's SNS KMS CMK. Additionally, the SNS resource policy must allow EventBridge to publish messages. This pull request fixes both issues allowing the SNS Topics to receive alert messages.