### PR TITLE
fix: scp updates for the deprecation of aws-portal and purchase-order namespaces

### DIFF
--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sandbox.json
@@ -10,7 +10,7 @@
         "aws-marketplace:DescribePrivate*",
         "aws-marketplace:DisassociateProducts*",
         "aws-marketplace:ListPrivate*",
-        "aws-marketplace:StartChangeSet"
+        "aws-marketplace:Start*"
       ],
       "Resource": "*"
     },
@@ -24,11 +24,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -103,9 +103,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -117,7 +115,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -134,7 +140,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -173,7 +178,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Sensitive.json
@@ -5,12 +5,12 @@
       "Sid": "PMP",
       "Effect": "Deny",
       "Action": [
-        "aws-marketplace:CreatePrivate*",
-        "aws-marketplace:AssociateProductsWithPrivate*",
-        "aws-marketplace:DescribePrivate*",
-        "aws-marketplace:DisassociateProducts*",
-        "aws-marketplace:ListPrivate*",
-        "aws-marketplace:StartChangeSet"
+        "aws-marketplace:As*",
+        "aws-marketplace:CreateP*",
+        "aws-marketplace:DescribePri*",
+        "aws-marketplace:Di*",
+        "aws-marketplace:ListP*",
+        "aws-marketplace:Start*"
       ],
       "Resource": "*"
     },
@@ -24,11 +24,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -103,9 +103,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -117,7 +115,15 @@
         "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -217,7 +223,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -258,9 +263,17 @@
         "s3:GetMultiR*",
         "s3:ListMultiR*",
         "s3:PutMultiR*",
-        "sso:DescribeRegisteredRegions",
         "sns:Publish",
-        "tag:GetResources"
+        "tag:GetResources",
+        "sso:DescribeRegisteredRegions",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
+++ b/reference-artifacts/SCPs/ASEA-Guardrails-Unclass.json
@@ -10,7 +10,7 @@
         "aws-marketplace:DescribePrivate*",
         "aws-marketplace:DisassociateProducts*",
         "aws-marketplace:ListPrivate*",
-        "aws-marketplace:StartChangeSet"
+        "aws-marketplace:Start*"
       ],
       "Resource": "*"
     },
@@ -24,11 +24,11 @@
         "iam:ListMFADevices",
         "iam:ListVirtualMFADevices",
         "iam:ResyncMFADevice",
-        "aws-portal:*",
         "sts:GetSessionToken",
         "iam:DeleteVirtualMFADevice",
         "trustedadvisor:*",
-        "support:*"
+        "support:*",
+        "account:*"
       ],
       "Resource": "*",
       "Condition": {
@@ -103,9 +103,7 @@
       "Effect": "Deny",
       "Action": [
         "organizations:LeaveOrg*",
-        "aws-portal:Modify*",
-        "aws-portal:ViewAccount",
-        "aws-portal:ViewPaymentMethods",
+        "organizations:CloseAccount",
         "ds:AcceptSharedDir*",
         "ds:ShareDir*",
         "ds:EnableSso",
@@ -114,10 +112,18 @@
         "ram:AssociateResourceShare",
         "ram:CreateResourceShare",
         "ram:EnableSharingWithAwsOrg*",
-        "lightsail:*",        
+        "lightsail:*",
         "gamelift:*",
         "appflow:*",
-        "iq:*"
+        "iq:*",
+        "account:P*",
+        "account:GetAl*",
+        "account:GetC*",
+        "account:GetR*",
+        "account:C*",
+        "account:D*",
+        "account:E*",
+        "account:L*"
       ],
       "Resource": "*",
       "Condition": {
@@ -198,7 +204,6 @@
         "access-analyzer:*",
         "aws-marketplace-management:*",
         "aws-marketplace:*",
-        "aws-portal:*",
         "budgets:*",
         "ce:*",
         "chime:*",
@@ -237,7 +242,15 @@
         "s3:DescribeMultiR*",
         "s3:GetMultiR*",
         "s3:ListMultiR*",
-        "s3:PutMultiR*"
+        "s3:PutMultiR*",
+        "billing:*",
+        "freetier:*",
+        "account:*",
+        "invoicing:*",
+        "payments:GetPaymentStatus",
+        "payments:ListPaymentPreferences",
+        "tax:ListTaxRegistrations",
+        "sustainability:*"
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

closes #1144 

Warning banner in the Billing Console will still exist until 7-JUL, or the new permissions are enabled from the 'Affected Policies' page [here](https://us-east-1.console.aws.amazon.com/poliden/home?region=us-east-1#/)

SCP size is calculated as the following: (<5120)
ASEA-Guardrails-Part0-CoreOUs.json     4963
ASEA-Guardrails-Part0-WkldOUs.json     4057
ASEA-Guardrails-Part1.json     4817
ASEA-Guardrails-Sandbox.json     3253
ASEA-Guardrails-Sensitive.json     4976
ASEA-Guardrails-Unclass.json     4646

Note that this also add sustainability to fix the Carbon Footprint dashboard.