### PR TITLE
Removing retired security hub controls

### DIFF
--- a/reference-artifacts/SAMPLE_CONFIGS/config.SSM-Patching-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.SSM-Patching-example.json
@@ -207,8 +207,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -216,7 +215,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example-oldIP.json
@@ -204,8 +204,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -213,7 +212,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.example.json
@@ -207,8 +207,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -216,7 +215,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-CTNFW-example.json
@@ -219,8 +219,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -228,7 +227,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-GWLB-example.json
@@ -207,8 +207,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -216,7 +215,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-NFW-example.json
@@ -202,8 +202,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -211,7 +210,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example-oldIP.json
@@ -204,8 +204,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -213,7 +212,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.lite-VPN-example.json
@@ -207,8 +207,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -216,7 +215,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.multi-region-example.json
@@ -211,8 +211,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -220,7 +219,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.test-example.json
@@ -267,8 +267,7 @@
           "name": "AWS Foundational Security Best Practices v1.0.0",
           "controls-to-disable": [
             "IAM.1",
-            "EC2.10",
-            "Lambda.4"
+            "EC2.10"
           ]
         },
         {
@@ -276,7 +275,6 @@
           "controls-to-disable": [
             "PCI.IAM.3",
             "PCI.S3.3",
-            "PCI.EC2.3",
             "PCI.Lambda.2"
           ]
         },

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-CT-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-CT-example.json
@@ -151,7 +151,7 @@
       "standards": [
         {
           "name": "AWS Foundational Security Best Practices v1.0.0",
-          "controls-to-disable": ["IAM.1", "EC2.10", "Lambda.4"]
+          "controls-to-disable": ["IAM.1", "EC2.10"]
         },
         {
           "name": "CIS AWS Foundations Benchmark v1.2.0",

--- a/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
+++ b/reference-artifacts/SAMPLE_CONFIGS/config.ultralite-example.json
@@ -150,7 +150,7 @@
       "standards": [
         {
           "name": "AWS Foundational Security Best Practices v1.0.0",
-          "controls-to-disable": ["IAM.1", "EC2.10", "Lambda.4"]
+          "controls-to-disable": ["IAM.1", "EC2.10"]
         },
         {
           "name": "CIS AWS Foundations Benchmark v1.2.0",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

AWS Security Hub retired controls Lambda.4 and PCI.EC2.3. Removing them from the sample configs. See https://docs.aws.amazon.com/securityhub/latest/userguide/doc-history.html
