### PR TITLE
Fix wrong argument passed to the updateTerminationProtection function

### DIFF
--- a/src/deployments/cdk/toolkit.ts
+++ b/src/deployments/cdk/toolkit.ts
@@ -261,7 +261,7 @@ export class CdkToolkit {
           this.deploymentLog(stack, 'Disabling termination protection');
           await cfn
             .updateTerminationProtection({
-              StackName: stack.id,
+              StackName: stack.stackName,
               EnableTerminationProtection: false,
             })
             .promise();
@@ -352,7 +352,7 @@ export class CdkToolkit {
       this.deploymentLog(stack, 'Disabling termination protection');
       await cfn
         .updateTerminationProtection({
-          StackName: stack.id,
+          StackName: stack.stackName,
           EnableTerminationProtection: false,
         })
         .promise();


### PR DESCRIPTION
The updateTerminationProtection function is getting a wrong argument "stack.id" which resulting the termination protection for stack not lifted and deletion of stack fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
