### PR TITLE
Security group rule fix

### DIFF
--- a/src/deployments/cdk/src/apps/phase-2.ts
+++ b/src/deployments/cdk/src/apps/phase-2.ts
@@ -44,6 +44,7 @@ import { logArchiveReadOnlyAccess } from '../deployments/s3/log-archive-read-acc
 import * as metadataDeployment from '../deployments/metadata-collection';
 import { IamRoleOutputFinder } from '@aws-accelerator/common-outputs/src/iam-role';
 import * as alb from '../deployments/alb';
+import { loadAssignedSubnetCidrPool } from '@aws-accelerator/common/src/util/common';
 
 /**
  * This is the main entry point to deploy phase 2
@@ -88,6 +89,8 @@ export async function deploy({
     config: acceleratorConfig,
     outputs,
   });
+
+  const assignedSubnetCidrPools = await loadAssignedSubnetCidrPool(context.subnetCidrPoolAssignedTable);
 
   await createTrail.step1({
     accountBuckets,
@@ -288,6 +291,7 @@ export async function deploy({
         vpcConfigs,
         sharedAccountKey,
         installerVersion: context.installerVersion,
+        subnetPools: assignedSubnetCidrPools,
       });
 
       // Add Tags Output

--- a/src/lib/common-types/src/types.ts
+++ b/src/lib/common-types/src/types.ts
@@ -223,6 +223,7 @@ export const region = enums(
     'ap-southeast-1',
     'ap-southeast-2',
     'ca-central-1',
+    'ca-west-1',
     'cn-north-1',
     'cn-northwest-1',
     'eu-central-1',


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This fixes the Security Group rules when referencing a different subnets. The code's lookup functionality was always returning empty because it had no data populated to query.

To verify:
1. In a workload account, inspect the Mgmt security group. With the default config, it is expected to see ingress rules with descriptions of 'Central VPC Traffic Inbound from...'
2. Apply fix and run state machine, expected Security Group Ingress rules exist.