### PR TITLE
fix for cross region s3 template processing

### DIFF
--- a/src/lib/cdk-constructs/src/firewall/instance.ts
+++ b/src/lib/cdk-constructs/src/firewall/instance.ts
@@ -84,6 +84,7 @@ export class FirewallInstance extends Construct {
     if (props.licenseBucket && props.licensePath) {
       new S3Template(this, 'License', {
         templateBucket: props.licenseBucket,
+        templateBucketRegion: configuration.bucketRegion,
         templatePath: props.licensePath,
         outputBucket: configuration.bucket,
         outputPath: props.licensePath,
@@ -93,6 +94,7 @@ export class FirewallInstance extends Construct {
     if (configuration.templateConfigPath) {
       this.template = new S3Template(this, 'Config', {
         templateBucket: configuration.templateBucket,
+        templateBucketRegion: configuration.bucketRegion,
         templatePath: configuration.templateConfigPath,
         outputBucket: configuration.bucket,
         outputPath: configuration.configPath,

--- a/src/lib/custom-resources/cdk-s3-template/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-s3-template/cdk/index.ts
@@ -24,6 +24,7 @@ const resourceType = 'Custom::S3Template';
 export interface S3TemplateProps {
   templateBucket: s3.IBucket;
   templatePath: string;
+  templateBucketRegion: string;
   outputBucket: s3.IBucket;
   outputPath: string;
 }
@@ -40,6 +41,7 @@ export class S3Template extends Construct {
     this.handlerProperties = {
       templateBucketName: props.templateBucket.bucketName,
       templatePath: props.templatePath,
+      templateBucketRegion: props.templateBucketRegion,
       outputBucketName: props.outputBucket.bucketName,
       outputPath: props.outputPath,
       parameters: {},


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This fixes the S3 API cross-region call when trying to provision 3rd party firewalls that use a configuration file. If the 3rd party firewalls are being deployed in ca-west-1, but the configuration files are in ca-central-1 (home region) this error will be encountered: `Error: Unable to get S3 object s3://asea-management-phase0-configcacentral1-1g9ucir5s5ry0/firewall/firewall-example-A-A-multitunnel.txt: IllegalLocationConstraintException: The ca-central-1 location constraint is incompatible for the region specific endpoint this request was sent to.`

The fix below uses the config bucket's home region as a parameter to the locationconstraint in the S3 API.