### PR TITLE
enables opt-in region for guardduty logging

### DIFF
--- a/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
+++ b/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
@@ -182,8 +182,8 @@ export async function step3(props: GuardDutyStep3Props) {
 export async function enableGuardDutyPolicy(props: GuardDutyStep3Props) {
   const { logBucket } = props;
 
-  let servicePrincipals = [new iam.ServicePrincipal('guardduty.amazonaws.com')];
-  const optin_regions = [
+  const servicePrincipals = [new iam.ServicePrincipal('guardduty.amazonaws.com')];
+  const optinRegions = [
     'af-south-1',
     'ap-east-1',
     'ap-south-2',
@@ -198,10 +198,10 @@ export async function enableGuardDutyPolicy(props: GuardDutyStep3Props) {
     'me-south-1',
   ];
 
-  optin_regions.map(optin_region => {
-    if (props.config['global-options']['supported-regions'].includes(optin_region)) {
+  optinRegions.map(optinRegion => {
+    if (props.config['global-options']['supported-regions'].includes(optinRegion)) {
       // Ideally want to query aws account list-regions --region-opt-status-contains ENABLED, and intersect with what is configured
-      servicePrincipals.push(new iam.ServicePrincipal(`guardduty.${optin_region}.amazonaws.com`));
+      servicePrincipals.push(new iam.ServicePrincipal(`guardduty.${optinRegion}.amazonaws.com`));
     }
   });
 

--- a/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
+++ b/src/deployments/cdk/src/deployments/guardduty/guardduty.ts
@@ -182,11 +182,34 @@ export async function step3(props: GuardDutyStep3Props) {
 export async function enableGuardDutyPolicy(props: GuardDutyStep3Props) {
   const { logBucket } = props;
 
+  let servicePrincipals = [new iam.ServicePrincipal('guardduty.amazonaws.com')];
+  const optin_regions = [
+    'af-south-1',
+    'ap-east-1',
+    'ap-south-2',
+    'ap-southeast-3',
+    'ap-southeast-4',
+    'ca-west-1',
+    'eu-central-2',
+    'eu-south-1',
+    'eu-south-2',
+    'il-central-1',
+    'me-central-1',
+    'me-south-1',
+  ];
+
+  optin_regions.map(optin_region => {
+    if (props.config['global-options']['supported-regions'].includes(optin_region)) {
+      // Ideally want to query aws account list-regions --region-opt-status-contains ENABLED, and intersect with what is configured
+      servicePrincipals.push(new iam.ServicePrincipal(`guardduty.${optin_region}.amazonaws.com`));
+    }
+  });
+
   // Grant GuardDuty permission to logBucket: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_exportfindings.html
   logBucket.addToResourcePolicy(
     new iam.PolicyStatement({
       actions: ['s3:GetBucketLocation', 's3:PutObject'],
-      principals: [new iam.ServicePrincipal('guardduty.amazonaws.com')],
+      principals: servicePrincipals,
       resources: [logBucket.bucketArn, logBucket.arnForObjects('*')],
     }),
   );
@@ -194,7 +217,7 @@ export async function enableGuardDutyPolicy(props: GuardDutyStep3Props) {
   logBucket.encryptionKey?.addToResourcePolicy(
     new iam.PolicyStatement({
       sid: 'Allow Guardduty to use the key',
-      principals: [new iam.ServicePrincipal('guardduty.amazonaws.com')],
+      principals: servicePrincipals,
       actions: ['kms:GenerateDataKey', 'kms:Encrypt'],
       resources: ['*'],
     }),


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


When configuring ca-west-1 the export configuration fails because service principal does not have permissions to write to the central log archive bucket and KMS Key. This Pull Request adds additional logic to support opt-in region service principals. 