### PR TITLE
fix for 1205

### DIFF
--- a/src/lib/cdk-constructs/src/vpc/asg.ts
+++ b/src/lib/cdk-constructs/src/vpc/asg.ts
@@ -101,7 +101,7 @@ export class RsysLogAutoScalingGroup extends Construct {
       autoScalingGroupName: `${props.acceleratorPrefix}RsyslogAutoScalingGroup`,
       launchTemplate: {
         launchTemplateId: launchTemplate.ref,
-        version: '1',
+        version: launchTemplate.attrLatestVersionNumber
       },
       vpcZoneIdentifier: props.subnetIds,
       maxInstanceLifetime: props.maxInstanceAge * 86400,

--- a/src/lib/cdk-constructs/src/vpc/asg.ts
+++ b/src/lib/cdk-constructs/src/vpc/asg.ts
@@ -101,7 +101,7 @@ export class RsysLogAutoScalingGroup extends Construct {
       autoScalingGroupName: `${props.acceleratorPrefix}RsyslogAutoScalingGroup`,
       launchTemplate: {
         launchTemplateId: launchTemplate.ref,
-        version: launchTemplate.attrLatestVersionNumber
+        version: launchTemplate.attrLatestVersionNumber,
       },
       vpcZoneIdentifier: props.subnetIds,
       maxInstanceLifetime: props.maxInstanceAge * 86400,


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This changes the AutoScalingGroup configuration to use the LaunchTemplate's latest version instead of the hardcoded "1". 

To test:
1. In the config file, change the  `"rsyslog-root-volume-size": 100` value to `150`.
2. Run the StateMachine

You should see the ASG referenced version to be the latest.