### PR TITLE
Opt-in region State Machine enhancements

### DIFF
--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -34,6 +34,7 @@ import { CreateControlTowerAccountTask } from './tasks/create-control-tower-acco
 import { CreateOrganizationAccountTask } from './tasks/create-organization-account-task';
 import { CreateStackTask } from './tasks/create-stack-task';
 import { RunAcrossAccountsTask } from './tasks/run-across-accounts-task';
+import { EnableOptinRegionTask } from './tasks/enable-optin-region-task';
 import { Construct } from 'constructs';
 import * as fs from 'fs';
 import * as sns from 'aws-cdk-lib/aws-sns';
@@ -626,11 +627,9 @@ export namespace InitialSetup {
       // Opt in Region - Begin
       const optinRegionsStateMachine = new sfn.StateMachine(this, `${props.acceleratorPrefix}OptinRegions_sm`, {
         stateMachineName: `${props.acceleratorPrefix}OptinRegions_sm`,
-        definition: new RunAcrossAccountsTask(this, 'OptinRegions', {
+        definition: new EnableOptinRegionTask(this, 'OptinRegions', {
           lambdaCode,
-          role: pipelineRole,
-          lambdaPath: 'index.enableOptinRegions',
-          name: 'Enable Opt-in Region',
+          role: pipelineRole
         }),
       });
 

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -629,7 +629,7 @@ export namespace InitialSetup {
         stateMachineName: `${props.acceleratorPrefix}OptinRegions_sm`,
         definition: new EnableOptinRegionTask(this, 'OptinRegions', {
           lambdaCode,
-          role: pipelineRole
+          role: pipelineRole,
         }),
       });
 

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -630,7 +630,7 @@ export namespace InitialSetup {
           lambdaCode,
           role: pipelineRole,
           lambdaPath: 'index.enableOptinRegions',
-          name: 'Enable Opt-in Regions',
+          name: 'Enable Opt-in Region',
         }),
       });
 

--- a/src/core/cdk/src/initial-setup.ts
+++ b/src/core/cdk/src/initial-setup.ts
@@ -636,6 +636,7 @@ export namespace InitialSetup {
       const optinRegionTask = new tasks.StepFunctionsStartExecution(this, 'Enable Opt-in Regions', {
         stateMachine: optinRegionsStateMachine,
         integrationPattern: sfn.IntegrationPattern.RUN_JOB,
+        resultPath: sfn.JsonPath.DISCARD,
         input: sfn.TaskInput.fromObject({
           'accounts.$': '$.accounts',
           'regions.$': '$.regions',
@@ -645,7 +646,6 @@ export namespace InitialSetup {
           'baseline.$': '$.baseline',
           acceleratorPrefix: props.acceleratorPrefix,
           assumeRoleName: props.stateMachineExecutionRole,
-          resultPath: sfn.JsonPath.DISCARD,
         }),
       });
 

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -53,7 +53,6 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
     const createTaskResultPath = '$.enableOutput';
     const createTaskResultLength = `${createTaskResultPath}.outputCount`;
 
-
     const enableTask = new CodeTask(scope, `Start Optin Region`, {
       resultPath: createTaskResultPath,
       functionProps: {
@@ -75,7 +74,7 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
         'configFilePath.$': '$.configFilePath',
         'configCommitId.$': '$.configCommitId',
         'acceleratorPrefix.$': '$.acceleratorPrefix',
-        'baseline.$': '$.baseline'
+        'baseline.$': '$.baseline',
       },
     });
     mapTask.iterator(enableTask);

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -113,8 +113,10 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
         .when(
           sfn.Condition.and(
             sfn.Condition.numberEquals(createTaskResultLength, 0),
-            sfn.Condition.numberEquals(createTaskErrorCount, 0)
-          ), pass) //already enabled or skipped
+            sfn.Condition.numberEquals(createTaskErrorCount, 0),
+          ),
+          pass,
+        ) //already enabled or skipped
         .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing
         .when(sfn.Condition.numberGreaterThan(createTaskErrorCount, 0), fail)
         .otherwise(fail)

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -66,7 +66,7 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
     // Create Map task to iterate
     const mapTask = new sfn.Map(this, `Enable Optin Region Map`, {
       itemsPath: '$.accounts',
-      resultPath: '$.errors',
+      resultPath: sfn.JsonPath.DISCARD,
       maxConcurrency: 15,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -110,7 +110,11 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
 
     enableTask.next(
       new sfn.Choice(scope, 'Optin Region Enablement Started?')
-        .when(sfn.Condition.numberEquals(createTaskResultLength, 0), pass) //already enabled or skipped
+        .when(
+          sfn.Condition.and(
+            sfn.Condition.numberEquals(createTaskResultLength, 0),
+            sfn.Condition.numberEquals(createTaskErrorCount, 0)
+          ), pass) //already enabled or skipped
         .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing
         .when(sfn.Condition.numberGreaterThan(createTaskErrorCount, 0), fail)
         .otherwise(fail)

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -108,7 +108,7 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
           .afterwards(),
       );
 
-    mapTask.next(
+    enableTask.next(
       new sfn.Choice(scope, 'Optin Region Enablement Started?')
         .when(sfn.Condition.numberLessThanEquals(createTaskResultLength, 0), pass) //already enabled or skipped
         .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -116,8 +116,8 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
             sfn.Condition.numberEquals(createTaskErrorCount, 0),
           ),
           pass,
-        ) //already enabled or skipped
-        .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing
+        ) // already enabled or skipped
+        .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) // processing
         .when(sfn.Condition.numberGreaterThan(createTaskErrorCount, 0), fail)
         .otherwise(fail)
         .afterwards(),

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -1,0 +1,103 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import { CodeTask } from '@aws-accelerator/cdk-accelerator/src/stepfunction-tasks';
+import { Construct } from 'constructs';
+
+export namespace EnableOptinRegionTask {
+  export interface Props {
+    role: iam.IRole;
+    lambdaCode: lambda.Code;
+    waitSeconds?: number;
+  }
+}
+
+export class EnableOptinRegionTask extends sfn.StateMachineFragment {
+  readonly startState: sfn.State;
+  readonly endStates: sfn.INextable[];
+
+  constructor(scope: Construct, id: string, props: EnableOptinRegionTask.Props) {
+    super(scope, id);
+
+    const { role, lambdaCode, waitSeconds = 60 } = props;
+
+    role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: ['*'],
+        actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
+      }),
+    );
+    role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: ['*'],
+        actions: ['codepipeline:PutJobSuccessResult', 'codepipeline:PutJobFailureResult'],
+      }),
+    );
+
+    const createTaskResultPath = '$.enableOutput';
+    const createTaskResultLength = `${createTaskResultPath}.outputCount`;
+    const createTask = new CodeTask(scope, `Start Optin Region`, {
+      resultPath: createTaskResultPath,
+      functionProps: {
+        role,
+        code: lambdaCode,
+        handler: 'index.enableOptinRegions.enable',
+      },
+    });
+
+    const verifyTaskResultPath = '$.verifyOutput';
+    const verifyTask = new CodeTask(scope, 'Verify Optin Region', {
+      resultPath: verifyTaskResultPath,
+      functionProps: {
+        role,
+        code: lambdaCode,
+        handler: 'index.enableOptinRegions.verify',
+      },
+    });
+
+    const waitTask = new sfn.Wait(scope, 'Wait for Optin Region Enabling', {
+      time: sfn.WaitTime.duration(cdk.Duration.seconds(waitSeconds)),
+    });
+
+    const pass = new sfn.Pass(this, 'Optin Region Enablement Succeeded');
+
+    const fail = new sfn.Fail(this, 'Optin Region Enablement Failed');
+
+    waitTask
+      .next(verifyTask)
+      .next(
+        new sfn.Choice(scope, 'Optin Region Enablement Done?')
+          .when(sfn.Condition.stringEquals(verifyTaskResultPath, 'SUCCESS'), pass)
+          .when(sfn.Condition.stringEquals(verifyTaskResultPath, 'IN_PROGRESS'), waitTask)
+          .otherwise(fail)
+          .afterwards(),
+      );
+
+    createTask.next(
+      new sfn.Choice(scope, 'Optin Region Enablement Started?')
+        .when(sfn.Condition.numberLessThanEquals(createTaskResultLength, 0), pass) //already enabled or skipped
+        .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing
+        .otherwise(fail)
+        .afterwards(),
+    );
+
+    this.startState = createTask.startState;
+    this.endStates = fail.endStates;
+  }
+}

--- a/src/core/cdk/src/tasks/enable-optin-region-task.ts
+++ b/src/core/cdk/src/tasks/enable-optin-region-task.ts
@@ -52,6 +52,7 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
 
     const createTaskResultPath = '$.enableOutput';
     const createTaskResultLength = `${createTaskResultPath}.outputCount`;
+    const createTaskErrorCount = `${createTaskResultPath}.errorCount`;
 
     const enableTask = new CodeTask(scope, `Start Optin Region`, {
       resultPath: createTaskResultPath,
@@ -109,8 +110,9 @@ export class EnableOptinRegionTask extends sfn.StateMachineFragment {
 
     enableTask.next(
       new sfn.Choice(scope, 'Optin Region Enablement Started?')
-        .when(sfn.Condition.numberLessThanEquals(createTaskResultLength, 0), pass) //already enabled or skipped
+        .when(sfn.Condition.numberEquals(createTaskResultLength, 0), pass) //already enabled or skipped
         .when(sfn.Condition.numberGreaterThan(createTaskResultLength, 0), waitTask) //processing
+        .when(sfn.Condition.numberGreaterThan(createTaskErrorCount, 0), fail)
         .otherwise(fail)
         .afterwards(),
     );

--- a/src/core/cdk/src/tasks/run-across-accounts-task.ts
+++ b/src/core/cdk/src/tasks/run-across-accounts-task.ts
@@ -77,8 +77,7 @@ export class RunAcrossAccountsTask extends sfn.StateMachineFragment {
 
     // Create Map task to iterate
     const mapTask = new sfn.Map(this, `${name} Map`, {
-      itemsPath: '$.accounts',
-      resultPath: '$.errors',
+      itemsPath: '$.accounts',      
       maxConcurrency: 50,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',

--- a/src/core/cdk/src/tasks/run-across-accounts-task.ts
+++ b/src/core/cdk/src/tasks/run-across-accounts-task.ts
@@ -77,7 +77,8 @@ export class RunAcrossAccountsTask extends sfn.StateMachineFragment {
 
     // Create Map task to iterate
     const mapTask = new sfn.Map(this, `${name} Map`, {
-      itemsPath: '$.accounts',      
+      itemsPath: '$.accounts',
+      resultPath: '$.errors',
       maxConcurrency: 50,
       parameters: {
         'accountId.$': '$$.Map.Item.Value',

--- a/src/core/runtime/src/enable-optin-regions/enable.ts
+++ b/src/core/runtime/src/enable-optin-regions/enable.ts
@@ -80,7 +80,7 @@ export const handler = async (input: EnableOptinRegionInput) => {
         if (enabledRegionStatus == 'not-opted-in') {
           console.log(`Enabling Opt-in region '${region}'`);
           try {
-            account.enableOptinRegion(accountId, region);
+            await account.enableOptinRegion(region);
             enabledOptinRegionList.push({
               accountId,
               optinRegionName: region,

--- a/src/core/runtime/src/enable-optin-regions/enable.ts
+++ b/src/core/runtime/src/enable-optin-regions/enable.ts
@@ -106,5 +106,5 @@ export const handler = async (input: EnableOptinRegionInput) => {
     console.log(`Control Tower is enabled. Skipping Opt-in enablement.`);
   }
 
-  return { enabledOptinRegionList, outputCount: enabledOptinRegionList.length, errors };
+  return { enabledOptinRegionList, outputCount: enabledOptinRegionList.length, errors, errorCount: errors.length };
 };

--- a/src/core/runtime/src/enable-optin-regions/enable.ts
+++ b/src/core/runtime/src/enable-optin-regions/enable.ts
@@ -78,11 +78,11 @@ export const handler = async (input: EnableOptinRegionInput) => {
       for (const region of supportedRegions) {
         const enabledRegionStatus = enabledRegionLookup[region];
 
-        //If region is an opt-in region
-        if (enabledRegionStatus == 'not-opted-in') {
-          //Check to see if it is Enabling state. This could happen during a SM restart.
+        // If region is an opt-in region
+        if (enabledRegionStatus === 'not-opted-in') {
+          // Check to see if it is Enabling state. This could happen during a SM restart.
           const optInRegionStatus = await account.getRegionOptinStatus(region);
-          if (optInRegionStatus.RegionOptStatus! == 'ENABLING') {
+          if (optInRegionStatus.RegionOptStatus! === 'ENABLING') {
             console.log(`Opt-in region '${region}' is already being enabled. Skipping.`);
             enabledOptinRegionList.push({
               accountId,
@@ -108,10 +108,10 @@ export const handler = async (input: EnableOptinRegionInput) => {
             );
             continue;
           }
-        } else if (enabledRegionStatus == 'opted-in') {
+        } else if (enabledRegionStatus === 'opted-in') {
           console.log(`${region} already opted-in`);
         } else {
-          //opt-in-not-required
+          // opt-in-not-required
           console.log(`${region} opt-in-not required`);
         }
       }

--- a/src/core/runtime/src/enable-optin-regions/enable.ts
+++ b/src/core/runtime/src/enable-optin-regions/enable.ts
@@ -1,0 +1,106 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { Account } from '@aws-accelerator/common/src/aws/account';
+import { EC2 } from '@aws-accelerator/common/src/aws/ec2';
+import { LoadConfigurationInput } from '../load-configuration-step';
+import { STS } from '@aws-accelerator/common/src/aws/sts';
+import { loadAcceleratorConfig } from '@aws-accelerator/common-config/src/load';
+import { Organizations } from '@aws-accelerator/common/src/aws/organizations';
+import { equalIgnoreCase } from '@aws-accelerator/common/src/util/common';
+
+interface EnableOptinRegionInput extends LoadConfigurationInput {
+  accountId: string;
+  assumeRoleName: string;
+}
+
+export interface EnableOptinRegionOutput {
+  accountId: string;
+  optinRegionName: string;
+  assumeRoleName: string;
+}
+
+const CustomErrorMessage = [
+  {
+    code: 'AuthFailure',
+    message: 'Region Not Enabled',
+  },
+  {
+    code: 'OptInRequired',
+    message: 'Region not Opted-in',
+  },
+];
+
+const sts = new STS();
+const organizations = new Organizations();
+export const handler = async (input: EnableOptinRegionInput) => {
+  console.log(`Enabling Opt-in Region in account ...`);
+  console.log(JSON.stringify(input, null, 2));
+  const { accountId, assumeRoleName, configRepositoryName, configFilePath, configCommitId } = input;
+
+  // Retrieve Configuration from Code Commit with specific commitId
+  const acceleratorConfig = await loadAcceleratorConfig({
+    repositoryName: configRepositoryName,
+    filePath: configFilePath,
+    commitId: configCommitId,
+  });
+  const awsAccount = await organizations.getAccount(accountId);
+  if (!awsAccount) {
+    // This will never happen unless it is called explicitly with invalid AccountId
+    throw new Error(`Unable to retrieve account info from Organizations API for "${accountId}"`);
+  }
+
+  const supportedRegions = acceleratorConfig['global-options']['supported-regions'];
+
+  console.log(`${accountId}: ${JSON.stringify(supportedRegions, null, 2)}`);
+  const errors: string[] = [];
+  const credentials = await sts.getCredentialsForAccountAndRole(accountId, assumeRoleName);
+  const account = new Account(credentials, 'us-east-1');
+  const ec2 = new EC2(credentials, 'us-east-1');
+
+  const enabledRegions = await ec2.describeAllRegions();
+  const enabledOptinRegionList: EnableOptinRegionOutput[] = [];
+  if (enabledRegions) {
+    const enabledRegionLookup = Object.fromEntries(enabledRegions.map(obj => [obj.RegionName, obj.OptInStatus]));
+
+    for (const region of supportedRegions) {
+      const enabledRegionStatus = enabledRegionLookup[region];
+      //If region is an opt-in region
+      if (enabledRegionStatus == 'not-opted-in') {
+        console.log(`Enabling Opt-in region '${region}'`);
+        try {
+          account.enableOptinRegion(accountId, region);
+          enabledOptinRegionList.push({
+            accountId,
+            optinRegionName: region,
+            assumeRoleName,
+          });
+        } catch (error: any) {
+          errors.push(
+            `${accountId}:${region}: ${error.code}: ${
+              CustomErrorMessage.find(cm => cm.code === error.code)?.message || error.message
+            }`,
+          );
+          continue;
+        }
+      } else if (enabledRegionStatus == 'opted-in') {
+        console.log(`${region} already opted-in`);
+      } else {
+        //opt-in-not-required
+        console.log(`${region} opt-in-not required`);
+      }
+    }
+  }
+
+  return { enabledOptinRegionList, outputCount: enabledOptinRegionList.length, errors };
+};

--- a/src/core/runtime/src/enable-optin-regions/index.ts
+++ b/src/core/runtime/src/enable-optin-regions/index.ts
@@ -11,5 +11,5 @@
  *  and limitations under the License.
  */
 
-export { handler as run } from './enable';
+export { handler as enable } from './enable';
 export { handler as verify } from './verify';

--- a/src/core/runtime/src/enable-optin-regions/index.ts
+++ b/src/core/runtime/src/enable-optin-regions/index.ts
@@ -1,0 +1,15 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export { handler as run } from './enable';
+export { handler as verify } from './verify';

--- a/src/core/runtime/src/enable-optin-regions/verify.ts
+++ b/src/core/runtime/src/enable-optin-regions/verify.ts
@@ -14,7 +14,6 @@
 import { Account } from '@aws-accelerator/common/src/aws/account';
 import { STS } from '@aws-accelerator/common/src/aws/sts';
 import { EnableOptinRegionOutput } from './enable';
-import { enableOptinRegion } from '..';
 
 interface StepInput {
   enableOutput: OptinRegionList;

--- a/src/core/runtime/src/enable-optin-regions/verify.ts
+++ b/src/core/runtime/src/enable-optin-regions/verify.ts
@@ -43,7 +43,7 @@ export const handler = async (input: StepInput): Promise<string> => {
     status.push(optInRegionStatus.RegionOptStatus!);
   }
 
-  //"ENABLED"|"ENABLING"|"DISABLING"|"DISABLED"|"ENABLED_BY_DEFAULT"|string;
+  // "ENABLED"|"ENABLING"|"DISABLING"|"DISABLED"|"ENABLED_BY_DEFAULT"|string;
 
   const statusEnabling = status.filter(s => s === 'ENABLING');
   if (statusEnabling && statusEnabling.length > 0) {

--- a/src/core/runtime/src/enable-optin-regions/verify.ts
+++ b/src/core/runtime/src/enable-optin-regions/verify.ts
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { Account } from '@aws-accelerator/common/src/aws/account';
+import { STS } from '@aws-accelerator/common/src/aws/sts';
+import { EnableOptinRegionOutput } from './enable';
+import { enableOptinRegion } from '..';
+
+interface StepInput {
+  enableOutput: OptinRegionList;
+}
+
+interface OptinRegionList {
+  enabledOptinRegionList: EnableOptinRegionOutput[];
+}
+
+export const handler = async (input: StepInput): Promise<string> => {
+  console.log(`Verifying status of enabled Optin Regions`);
+  console.log(JSON.stringify(input, null, 2));
+
+  const status: string[] = [];
+  const sts = new STS();
+
+  for (const enabledOptinRegion of input.enableOutput.enabledOptinRegionList) {
+    const credentials = await sts.getCredentialsForAccountAndRole(
+      enabledOptinRegion.accountId,
+      enabledOptinRegion.assumeRoleName,
+    );
+
+    const account = new Account(credentials, 'us-east-1');
+
+    const optInRegionStatus = await account.getRegionOptinStatus(enabledOptinRegion.optinRegionName);
+
+    status.push(optInRegionStatus.RegionOptStatus!);
+  }
+
+  //"ENABLED"|"ENABLING"|"DISABLING"|"DISABLED"|"ENABLED_BY_DEFAULT"|string;
+
+  const statusEnabling = status.filter(s => s === 'ENABLING');
+  if (statusEnabling && statusEnabling.length > 0) {
+    return 'IN_PROGRESS';
+  }
+
+  const statusDisabling = status.filter(s => s === 'DISABLING');
+  if (statusDisabling && statusDisabling.length > 0) {
+    return 'IN_PROGRESS';
+  }
+
+  return 'SUCCESS';
+};

--- a/src/core/runtime/src/index.ts
+++ b/src/core/runtime/src/index.ts
@@ -49,6 +49,7 @@ import * as createOrganizationAccount from './create-organization-account';
 import * as createStack from './create-stack';
 import * as createStackSet from './create-stack-set';
 import * as deleteDefaultVpcs from './delete-default-vpc';
+import * as enableOptinRegion from './enable-optin-regions';
 export {
   createAccount,
   createStack,
@@ -58,4 +59,5 @@ export {
   deleteDefaultVpcs,
   createConfigRecorder,
   addTagsToSharedResources,
+  enableOptinRegion,
 };

--- a/src/core/runtime/src/index.ts
+++ b/src/core/runtime/src/index.ts
@@ -49,7 +49,7 @@ import * as createOrganizationAccount from './create-organization-account';
 import * as createStack from './create-stack';
 import * as createStackSet from './create-stack-set';
 import * as deleteDefaultVpcs from './delete-default-vpc';
-import * as enableOptinRegion from './enable-optin-regions';
+import * as enableOptinRegions from './enable-optin-regions';
 export {
   createAccount,
   createStack,
@@ -59,5 +59,5 @@ export {
   deleteDefaultVpcs,
   createConfigRecorder,
   addTagsToSharedResources,
-  enableOptinRegion,
+  enableOptinRegions,
 };

--- a/src/lib/common/src/aws/account.ts
+++ b/src/lib/common/src/aws/account.ts
@@ -48,6 +48,7 @@ export class Account {
     const params: GetRegionOptStatusRequest = {
       RegionName: regionName,
     };
-    return await throttlingBackOff(() => this.client.getRegionOptStatus(params).promise());
+    const result = await throttlingBackOff(() => this.client.getRegionOptStatus(params).promise());
+    return result;
   }
 }

--- a/src/lib/common/src/aws/account.ts
+++ b/src/lib/common/src/aws/account.ts
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ *  with the License. A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the 'license' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+ *  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import aws from './aws-client';
+import { EnableRegionRequest, GetRegionOptStatusRequest, GetRegionOptStatusResponse } from 'aws-sdk/clients/account';
+import { throttlingBackOff } from './backoff';
+import { listWithNextToken, listWithNextTokenGenerator } from './next-token';
+import { collectAsync } from '../util/generator';
+
+export class Account {
+  private readonly client: aws.Account;
+
+  public constructor(credentials?: aws.Credentials, region?: string) {
+    this.client = new aws.Account({
+      region,
+      credentials,
+    });
+  }
+
+  /**
+   * enables opt-in region
+   * @param accountId
+   * @param regionName
+   */
+  async enableOptinRegion(accountId: string, regionName: string): Promise<void> {
+    const params: EnableRegionRequest = {
+      AccountId: accountId,
+      RegionName: regionName,
+    };
+    await throttlingBackOff(() => this.client.enableRegion(params).promise());
+  }
+
+  /**
+   * gets Region Optin Status
+   * @param accountId
+   * @param regionName
+   */
+  async getRegionOptinStatus(regionName: string): Promise<GetRegionOptStatusResponse> {
+    const params: GetRegionOptStatusRequest = {
+      RegionName: regionName,
+    };
+    return await throttlingBackOff(() => this.client.getRegionOptStatus(params).promise());
+  }
+}

--- a/src/lib/common/src/aws/account.ts
+++ b/src/lib/common/src/aws/account.ts
@@ -32,9 +32,8 @@ export class Account {
    * @param accountId
    * @param regionName
    */
-  async enableOptinRegion(accountId: string, regionName: string): Promise<void> {
+  async enableOptinRegion(regionName: string): Promise<void> {
     const params: EnableRegionRequest = {
-      AccountId: accountId,
       RegionName: regionName,
     };
     await throttlingBackOff(() => this.client.enableRegion(params).promise());

--- a/src/lib/common/src/aws/ec2.ts
+++ b/src/lib/common/src/aws/ec2.ts
@@ -17,12 +17,15 @@ import {
   EnableEbsEncryptionByDefaultResult,
   ModifyEbsDefaultKmsKeyIdRequest,
   ModifyEbsDefaultKmsKeyIdResult,
+  DescribeRegionsRequest,
+  DescribeRegionsResult,
   InternetGatewayList,
   VpcList,
   DescribeSubnetsRequest,
   SubnetList,
   DescribeSubnetsResult,
   Subnet,
+  RegionList,
 } from 'aws-sdk/clients/ec2';
 import { throttlingBackOff } from './backoff';
 import { listWithNextToken, listWithNextTokenGenerator } from './next-token';
@@ -162,5 +165,16 @@ export class EC2 {
       r => r.Subnets!,
       input,
     );
+  }
+
+  /**
+   * Wrapper around AWS.EC2.describeRegions.
+   */
+  async describeAllRegions(): Promise<aws.EC2.RegionList | undefined> {
+    const params: DescribeRegionsRequest = {
+      AllRegions: true,
+    };
+    const regions = await throttlingBackOff(() => this.client.describeRegions(params).promise());
+    return regions.Regions;
   }
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This PR introduces a new step in the State Machine that executes a new State Machine that enables opt-in regions, and waits until the enabling is complete. The new SM is configured to run 15 accounts concurrently.

Main State Machine:
![image](https://github.com/aws-samples/aws-secure-environment-accelerator/assets/41204211/ef85c24f-c241-4e41-96de-ecb910068adb)

New OptIn State Machine:
![image](https://github.com/aws-samples/aws-secure-environment-accelerator/assets/41204211/3b190aa4-1103-40f9-a7dc-cd9e6202b134)

<img width="592" alt="image" src="https://github.com/aws-samples/aws-secure-environment-accelerator/assets/41204211/33430a06-29cd-48a8-b4d6-4fde871b3c1d">


This improves the experience when creating new AWS accounts by having the SM enable the region instead of using an external script.