### PR TITLE
fix for tgw peering multiple attachments issue

### DIFF
--- a/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
@@ -40,6 +40,9 @@ export class TransitGatewayAcceptPeeringAttachment extends Construct {
       ++TransitGatewayAcceptPeeringAttachment.attachmentCount > 1
         ? `${resourceType}Role${TransitGatewayAcceptPeeringAttachment.attachmentCount}`
         : `${resourceType}Role`;
+
+    console.log(`TransitGatewayCreatePeeringAttachment: constructId ${roleConstructId} for ${id}`);
+
     this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {

--- a/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
@@ -41,8 +41,6 @@ export class TransitGatewayAcceptPeeringAttachment extends Construct {
         ? `${resourceType}Role${TransitGatewayAcceptPeeringAttachment.attachmentCount}`
         : `${resourceType}Role`;
 
-    console.log(`TransitGatewayCreatePeeringAttachment: constructId ${roleConstructId} for ${id}`);
-
     this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {

--- a/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
@@ -31,7 +31,7 @@ export interface TransitGatewayAcceptPeeringAttachmentProps {
 export class TransitGatewayAcceptPeeringAttachment extends Construct {
   private readonly resource: cdk.CustomResource;
   private readonly role: iam.IRole;
-  private static attachmentCount: number;
+  private static attachmentCount: number = 0;
 
   constructor(scope: Construct, id: string, props: TransitGatewayAcceptPeeringAttachmentProps) {
     super(scope, id);

--- a/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-accept-peering/cdk/index.ts
@@ -31,11 +31,16 @@ export interface TransitGatewayAcceptPeeringAttachmentProps {
 export class TransitGatewayAcceptPeeringAttachment extends Construct {
   private readonly resource: cdk.CustomResource;
   private readonly role: iam.IRole;
+  private static attachmentCount: number;
 
   constructor(scope: Construct, id: string, props: TransitGatewayAcceptPeeringAttachmentProps) {
     super(scope, id);
 
-    this.role = iam.Role.fromRoleArn(scope, `${resourceType}Role`, props.roleArn);
+    const roleConstructId =
+      ++TransitGatewayAcceptPeeringAttachment.attachmentCount > 1
+        ? `${resourceType}Role${TransitGatewayAcceptPeeringAttachment.attachmentCount}`
+        : `${resourceType}Role`;
+    this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {
       resourceType,

--- a/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
@@ -34,12 +34,18 @@ export interface TransitGatewayCreatePeeringAttachmentProps {
 export class TransitGatewayCreatePeeringAttachment extends Construct {
   private readonly resource: cdk.CustomResource;
   private readonly role: iam.IRole;
+  private static attachmentCount: number;
 
   constructor(scope: Construct, id: string, props: TransitGatewayCreatePeeringAttachmentProps) {
     super(scope, id);
 
     const { transitGatewayId, targetTransitGatewayId, targetAccountId, targetRegion, tagValue } = props;
-    this.role = iam.Role.fromRoleArn(scope, `${resourceType}Role`, props.roleArn);
+
+    const roleConstructId =
+      ++TransitGatewayCreatePeeringAttachment.attachmentCount > 1
+        ? `${resourceType}Role${TransitGatewayCreatePeeringAttachment.attachmentCount}`
+        : `${resourceType}Role`;
+    this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {
       resourceType,

--- a/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
@@ -34,7 +34,7 @@ export interface TransitGatewayCreatePeeringAttachmentProps {
 export class TransitGatewayCreatePeeringAttachment extends Construct {
   private readonly resource: cdk.CustomResource;
   private readonly role: iam.IRole;
-  private static attachmentCount: number;
+  private static attachmentCount: number = 0;
 
   constructor(scope: Construct, id: string, props: TransitGatewayCreatePeeringAttachmentProps) {
     super(scope, id);

--- a/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
@@ -41,15 +41,11 @@ export class TransitGatewayCreatePeeringAttachment extends Construct {
 
     const { transitGatewayId, targetTransitGatewayId, targetAccountId, targetRegion, tagValue } = props;
 
-    console.log(`TransitGatewayCreatePeeringAttachment: before attachmentCount ${TransitGatewayCreatePeeringAttachment.attachmentCount}`);
-
     const roleConstructId =
       ++TransitGatewayCreatePeeringAttachment.attachmentCount > 1
         ? `${resourceType}Role${TransitGatewayCreatePeeringAttachment.attachmentCount}`
         : `${resourceType}Role`;
 
-    console.log(`TransitGatewayCreatePeeringAttachment: after attachmentCount ${TransitGatewayCreatePeeringAttachment.attachmentCount}`);
-    console.log(`TransitGatewayCreatePeeringAttachment: constructId ${roleConstructId} for ${id}`);
     this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {

--- a/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
+++ b/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts
@@ -41,10 +41,15 @@ export class TransitGatewayCreatePeeringAttachment extends Construct {
 
     const { transitGatewayId, targetTransitGatewayId, targetAccountId, targetRegion, tagValue } = props;
 
+    console.log(`TransitGatewayCreatePeeringAttachment: before attachmentCount ${TransitGatewayCreatePeeringAttachment.attachmentCount}`);
+
     const roleConstructId =
       ++TransitGatewayCreatePeeringAttachment.attachmentCount > 1
         ? `${resourceType}Role${TransitGatewayCreatePeeringAttachment.attachmentCount}`
         : `${resourceType}Role`;
+
+    console.log(`TransitGatewayCreatePeeringAttachment: after attachmentCount ${TransitGatewayCreatePeeringAttachment.attachmentCount}`);
+    console.log(`TransitGatewayCreatePeeringAttachment: constructId ${roleConstructId} for ${id}`);
     this.role = iam.Role.fromRoleArn(scope, roleConstructId, props.roleArn);
 
     this.resource = new cdk.CustomResource(this, 'Resource', {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This changes fixes the CDK errors when trying to peer more than 1 TGW.

Original Error
```
rror: There is already a Construct with name 'Custom::TGWCreatePeeringAttachmentRole' in AccountStack [SharedNetworkPhase1CaWest_1]
    at Node.addChild (/app/node_modules/.pnpm/constructs@10.2.70/node_modules/constructs/src/construct.ts:428:13)
    at new Node (/app/node_modules/.pnpm/constructs@10.2.70/node_modules/constructs/src/construct.ts:71:17)
    at new Construct (/app/node_modules/.pnpm/constructs@10.2.70/node_modules/constructs/src/construct.ts:480:17)
    at new Resource (/app/node_modules/.pnpm/aws-cdk-lib@2.101.0_constructs@10.2.70/node_modules/aws-cdk-lib/core/lib/resource.js:1:1309)
    at new ImportedRole (/app/node_modules/.pnpm/aws-cdk-lib@2.101.0_constructs@10.2.70/node_modules/aws-cdk-lib/aws-iam/lib/private/imported-role.js:1:615)
    at Function.fromRoleArn (/app/node_modules/.pnpm/aws-cdk-lib@2.101.0_constructs@10.2.70/node_modules/aws-cdk-lib/aws-iam/lib/role.js:1:3167)
    at new TransitGatewayCreatePeeringAttachment (/app/src/lib/custom-resources/cdk-transit-gateway-create-peering/cdk/index.ts:48:26)
    at Object.createPeeringAttachment (/app/src/deployments/cdk/src/deployments/transit-gateway/peering.ts:86:47)
    at deploy (/app/src/deployments/cdk/src/apps/phase-1.ts:601:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```