### PR TITLE
fix(snapshot): ignore infrequent access log groups in subscription filter

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/common/aws/backoff.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/common/aws/backoff.ts
@@ -51,12 +51,14 @@ export const isThrottlingError = (
   e.code === 'EPIPE' ||
   e.code === 'ETIMEDOUT' ||
   e.code === 'ENOTFOUND' ||
+  e.code === 'RequestLimitExceeded' ||
   // SDKv3 Error Structure
   e.name === 'ConcurrentModificationException' || // Retry for AWS Organizations
   e.name === 'InsufficientDeliveryPolicyException' || // Retry for ConfigService
   e.name === 'NoAvailableDeliveryChannelException' || // Retry for ConfigService
   e.name === 'ConcurrentModifications' || // Retry for AssociateHostedZone
   e.name === 'LimitExceededException' || // Retry for SecurityHub
+  e.name === 'RequestLimitExceeded' ||
   e.name === 'OperationNotPermittedException' || // Retry for RAM
   e.name === 'TooManyRequestsException' ||
   e.name === 'Throttling' ||


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The Infrequent Access Log Class doesn't support subscription filters. This modification ignores them when describing log groups subscription filters in the custom resource snapshot.