### PR TITLE
fix(snapshot) skip subscription filters for IA log groups

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/snapshot/lib/aws-cloudwatch.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/snapshot/lib/aws-cloudwatch.ts
@@ -20,6 +20,7 @@ import {
   LogGroup,
   MetricFilter,
   SubscriptionFilter,
+  LogGroupClass,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 
@@ -170,19 +171,21 @@ export async function snapshotCloudWatchLogResources(
           });
         }
 
+        if (logGroup.logGroupClass && logGroup.logGroupClass !== LogGroupClass.INFREQUENT_ACCESS) {
         //get subscription filters
-        const subscriptionFilterResults = await describeSubscriptionFilters(
-          logGroup.logGroupName!,
-          region,
-          credentials,
-        );
-        await snapshotTable.writeResource({
-          accountId: accountId,
-          region: region,
-          resourceName: `subscription-filters-${logGroup.logGroupName!}`,
-          preMigration: preMigration,
-          data: subscriptionFilterResults,
-        });
+          const subscriptionFilterResults = await describeSubscriptionFilters(
+            logGroup.logGroupName!,
+            region,
+            credentials,
+          );
+          await snapshotTable.writeResource({
+            accountId: accountId,
+            region: region,
+            resourceName: `subscription-filters-${logGroup.logGroupName!}`,
+            preMigration: preMigration,
+            data: subscriptionFilterResults,
+          });
+        }
       }
     }
   } while (nextToken);


### PR DESCRIPTION
Skip over subscription filters for log groups with infrequent access storage when running the snapshot tool.
