### PR TITLE
Revert "Bump aws-cdk-lib from 2.101.0 to 2.187.0 in /src/lib/custom-resources/cdk-guardduty-create-publish"

### DIFF
--- a/src/lib/custom-resources/cdk-guardduty-create-publish/package.json
+++ b/src/lib/custom-resources/cdk-guardduty-create-publish/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aws-accelerator/custom-resource-guardduty-create-publish-runtime": "workspace:*",
-    "aws-cdk-lib": "2.187.0",
+    "aws-cdk-lib": "2.101.0",
     "constructs": "10.2.70"
   },
   "devDependencies": {
@@ -25,6 +25,6 @@
   },
   "peerDependencies": {
     "@aws-accelerator/custom-resource-guardduty-create-publish-runtime": "workspace:*",
-    "aws-cdk-lib": "2.187.0"
+    "aws-cdk-lib": "2.101.0"
   }
 }


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#1267