### PR TITLE
Revert "Bump aws-cdk-lib from 2.101.0 to 2.187.0 in /src/lib/custom-resources/cdk-logs-resource-policy"

### DIFF
--- a/src/lib/custom-resources/cdk-logs-resource-policy/package.json
+++ b/src/lib/custom-resources/cdk-logs-resource-policy/package.json
@@ -8,7 +8,7 @@
     "lint:eslint": "pnpx eslint '{cdk,lib,src}/**/*.{js,ts}'"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.187.0",
+    "aws-cdk-lib": "2.101.0",
     "constructs": "10.2.70"
   },
   "devDependencies": {
@@ -17,6 +17,6 @@
     "typescript": "5.2.2"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.187.0"
+    "aws-cdk-lib": "2.101.0"
   }
 }


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#1268