### PR TITLE
Revert "Bump aws-cdk-lib from 2.101.0 to 2.187.0 in /src/lib/custom-resources/cdk-macie-update-session"

### DIFF
--- a/src/lib/custom-resources/cdk-macie-update-session/package.json
+++ b/src/lib/custom-resources/cdk-macie-update-session/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@aws-accelerator/custom-resource-macie-enable-runtime": "workspace:*",
     "@aws-accelerator/custom-resource-macie-update-session-runtime": "workspace:*",
-    "aws-cdk-lib": "2.187.0",
+    "aws-cdk-lib": "2.101.0",
     "constructs": "10.2.70"
   },
   "devDependencies": {
@@ -27,6 +27,6 @@
   "peerDependencies": {
     "@aws-accelerator/custom-resource-macie-enable-runtime": "workspace:*",
     "@aws-accelerator/custom-resource-macie-update-session-runtime": "workspace:*",
-    "aws-cdk-lib": "2.187.0"
+    "aws-cdk-lib": "2.101.0"
   }
 }


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#1269