### PR TITLE
Revert "Bump aws-cdk-lib from 2.101.0 to 2.187.0 in /src/lib/custom-resources/cdk-r53-dns-endpoint-ips"

### DIFF
--- a/src/lib/custom-resources/cdk-r53-dns-endpoint-ips/package.json
+++ b/src/lib/custom-resources/cdk-r53-dns-endpoint-ips/package.json
@@ -8,13 +8,13 @@
     "lint:eslint": "pnpx eslint '{cdk,lib,src}/**/*.{js,ts}'"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.187.0",
+    "aws-cdk-lib": "2.101.0",
     "constructs": "10.2.70"
   },
   "devDependencies": {
     "@types/node": "20.8.0"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.187.0"
+    "aws-cdk-lib": "2.101.0"
   }
 }


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#1270