### PR TITLE
Revert "Bump esbuild from 0.19.4 to 0.25.0 in /src/core/runtime"

### DIFF
--- a/src/core/runtime/package.json
+++ b/src/core/runtime/package.json
@@ -33,7 +33,7 @@
     "@types/jest": "29.5.5",
     "@types/node": "20.8.0",
     "@types/uuid": "9.0.4",
-    "esbuild": "0.25.0",
+    "esbuild": "0.19.4",
     "eslint": "8.50.0",
     "jest": "29.7.0",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
Reverts aws-samples/aws-secure-environment-accelerator#1246