### PR TITLE
Run snapshot only in ASEA managed accounts

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/snapshot.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/snapshot.ts
@@ -25,6 +25,7 @@ export class Snapshot {
   private readonly aseaConfigRepositoryName: string;
   private readonly localConfigFilePath: string | undefined;
   private readonly preMigrationSnapshot: boolean;
+  private readonly parametersTableName: string;
 
   constructor(config: Config) {
     this.aseaPrefix = config.aseaPrefix ?? 'ASEA-';
@@ -34,6 +35,7 @@ export class Snapshot {
     this.aseaConfigRepositoryName = config.repositoryName;
     this.localConfigFilePath = config.localConfigFilePath;
     this.preMigrationSnapshot = false;
+    this.parametersTableName = config.parametersTableName;
   }
 
   async pre() {
@@ -50,6 +52,7 @@ export class Snapshot {
       this.aseaPrefix,
       true,
       aseaConfig,
+      this.parametersTableName
     );
   }
 
@@ -67,6 +70,7 @@ export class Snapshot {
       this.aseaPrefix,
       this.preMigrationSnapshot,
       aseaConfig,
+      this.parametersTableName
     );
   }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fetch the list of accounts for snapshot from ASEA Dynamo DB Table instead of AWS Organizations. This ensure snapshot is not run on accounts ignored by ASEA where ASEA cannot assume credentials.
