### PR TITLE
fix(convert-config): set globalServiceEvents to true for multiRegionTrail

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
@@ -749,7 +749,7 @@ export class ConvertAseaConfig {
         organizationTrail: true,
         organizationTrailSettings: {
           multiRegionTrail: true,
-          globalServiceEvents: false,
+          globalServiceEvents: true,
           managementEvents: false,
           s3DataEvents: true,
           lambdaDataEvents: false,
@@ -2973,7 +2973,7 @@ export class ConvertAseaConfig {
               sourceVpcConfig = this.vpcConfigs.find(({ vpcConfig }) => vpcConfig.name === source.vpc);
             }
             if (SecurityGroupSourceConfig.is(source)) {
-              lzaRule.sources.push({ 
+              lzaRule.sources.push({
                 securityGroups: source['security-group'].map(securityGroupName),
               });
             } else if (SubnetSourceConfig.is(source)) {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Because multiRegionTrail is set to true, LZA expects that globalServiceEvents should also be true, otherwise it generates this error during validation:

```
The organization CloudTrail setting multiRegionTrail is enabled, the globalServiceEvents must be enabled as well
```

This PR fixes this by setting `globalServiceEvents` to true in convert-config.