### PR TITLE
fix(convert-config): relax condition to find SCPs statement that need modification for LZA

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
@@ -2050,7 +2050,7 @@ export class ConvertAseaConfig {
         });
       }
       const policyJson = JSON.parse(policyData);
-      if (scpName.includes('Guardrails-Part-1') || scpName.includes('Guardrails-Part-0')) {
+      if (scpName.includes('Part-1') || scpName.includes('Part-0')) {
         const newStatements = policyJson.Statement.map((stmt: any) => {
           if (stmt.Sid === 'SSM' || stmt.Sid === 'S3' || (stmt.Condition && stmt.Condition['ForAnyValue:StringLike'])) {
             console.log('Adding Org admin role to scp');


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

In convert-config LZA needs to add the OrgAdminRole to some SCP statements. This PR changes the condition that lookup the statements in the Part-0 and Part-1 file to increase the chance it matches the right SCPs if the user customized their name.