### PR TITLE
fixes issue with CloudWatch Logs custom log KMS permissions

### DIFF
--- a/src/deployments/cdk/src/deployments/iam/log-group-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/log-group-role.ts
@@ -51,5 +51,12 @@ async function createRole(stack: AccountStack) {
       resources: ['*'],
     }),
   );
+
+  role.addToPrincipalPolicy(
+    new iam.PolicyStatement({
+      actions: ['kms:Encrypt', 'kms:GenerateDataKey'],
+      resources: ['*'],
+    }),
+  );
   return role;
 }

--- a/src/deployments/cdk/src/deployments/iam/log-group-role.ts
+++ b/src/deployments/cdk/src/deployments/iam/log-group-role.ts
@@ -54,7 +54,7 @@ async function createRole(stack: AccountStack) {
 
   role.addToPrincipalPolicy(
     new iam.PolicyStatement({
-      actions: ['kms:Encrypt', 'kms:GenerateDataKey'],
+      actions: ['kms:Encrypt', 'kms:Decrypt', 'kms:GenerateDataKey'],
       resources: ['*'],
     }),
   );

--- a/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
+++ b/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
@@ -146,7 +146,7 @@ export class PrebuiltCdkDeployProject extends CdkDeployProjectBase {
     fs.writeFileSync(
       path.join(this.projectTmpDir, 'Dockerfile'),
       [
-        'FROM public.ecr.aws/bitnami/node:22',
+        'FROM public.ecr.aws/bitnami/node:22.13.0',
         // Install the package manager
         ...installPackageManagerCommands(props.packageManager).map(cmd => `RUN ${cmd}`),
         `WORKDIR ${appDir}`,
@@ -194,7 +194,7 @@ export class PrebuiltCdkDeployProject extends CdkDeployProjectBase {
  */
 function installPackageManagerCommands(packageManager: PackageManager) {
   if (packageManager === 'pnpm') {
-    return ['npm install --global pnpm@10.11.0 --force'];
+    return ['npm install --global pnpm@10.11.0'];
   }
   throw new Error(`Unsupported package manager ${packageManager}`);
 }

--- a/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
+++ b/src/lib/cdk-accelerator/src/codebuild/cdk-deploy-project.ts
@@ -194,7 +194,7 @@ export class PrebuiltCdkDeployProject extends CdkDeployProjectBase {
  */
 function installPackageManagerCommands(packageManager: PackageManager) {
   if (packageManager === 'pnpm') {
-    return ['npm install --global pnpm@10.11.0'];
+    return ['npm install --global pnpm@10.11.0 --force'];
   }
   throw new Error(`Unsupported package manager ${packageManager}`);
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This PR adds the KMS Encrypt, Decrypt, and GenerateDataKey to the CustomResource IAM Role.
This resolves the new error: `assumed-role/ASEA-Perimeter-Phase-1-CustomLogsLogGroup49AC86AD-NKwAHgWk8y9J/ASEA-Perimeter-Phase1-CustomLogsLogGroupLambda2441-PUpuy08ZjI1K is not authorized to perform: kms:Encrypt on resource`