### PR TITLE
fix: bump python version to 3.11 for SSM Documents

### DIFF
--- a/reference-artifacts/ssm-documents/attach-iam-role-policy.yaml
+++ b/reference-artifacts/ssm-documents/attach-iam-role-policy.yaml
@@ -16,7 +16,7 @@ mainSteps:
   - name: attachPolicy
     action: 'aws:executeScript'
     inputs:
-      Runtime: python3.7
+      Runtime: python3.11
       Handler: script_handler
       Script: |-
         import boto3

--- a/reference-artifacts/ssm-documents/ssm-patching-role-tagging.yaml
+++ b/reference-artifacts/ssm-documents/ssm-patching-role-tagging.yaml
@@ -16,7 +16,7 @@ mainSteps:
   - name: LookupRole
     action: 'aws:executeScript'
     inputs:
-      Runtime: python3.8
+      Runtime: python3.11
       Handler: getRoleName
       InputPayload:
         roleId: '{{RoleId}}'


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Update the python version to 3.11 in the SSM Documents ahead of the 10-SEPT deprecation date.