### PR TITLE
fix(convert-config): build tgw routes for VPN connections

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
@@ -2805,7 +2805,7 @@ export class ConvertAseaConfig {
           };
         } else if (route['target-vpn']) {
           return {
-            vpnConnectionName: route['target-vpn'],
+            vpnConnectionName: route['target-vpn']['name'],
           };
         } else if (route['target-tgw']) {
           if (tgwConfig['tgw-attach'] && tgwConfig['tgw-attach']['associate-to-tgw'] === route['target-tgw']) {
@@ -2973,7 +2973,7 @@ export class ConvertAseaConfig {
               sourceVpcConfig = this.vpcConfigs.find(({ vpcConfig }) => vpcConfig.name === source.vpc);
             }
             if (SecurityGroupSourceConfig.is(source)) {
-              lzaRule.sources.push({ 
+              lzaRule.sources.push({
                 securityGroups: source['security-group'].map(securityGroupName),
               });
             } else if (SubnetSourceConfig.is(source)) {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Use name attribute to build vpnConnectionName for TGW VPN attachments in convert config.