### PR TITLE
fix(convert-config): don't skip certificate config if it contains duplicates

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/convert-config.ts
@@ -2760,7 +2760,12 @@ export class ConvertAseaConfig {
               accountKey,
             );
           }
-          if (processedCertificates.has(certificate.name)) return;
+          if (processedCertificates.has(certificate.name)) {
+            this.configCheck.addWarning(
+              `Certificate ${certificate.name} found for multiple accounts (${accountKey}). Only the first configuration is converted. Verify your configuration.`,
+            );
+            continue;
+          }
           certificates.push(await getTransformedCertificate(certificate));
           processedCertificates.add(certificate.name);
         }
@@ -2784,7 +2789,12 @@ export class ConvertAseaConfig {
               );
             }
           }
-          if (processedCertificates.has(certificate.name)) return;
+          if (processedCertificates.has(certificate.name)) {
+            this.configCheck.addWarning(
+              `Certificate ${certificate.name} found for multiple OUs (${ouKey}). Only the first configuration is converted. Verify your configuration.`,
+            );
+            continue;
+          }
           certificates.push(await getTransformedCertificate(certificate));
           processedCertificates.add(certificate.name);
         }


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This fix an issue in convert-config where it could skip generation of the `certificates` blocks if the original ASEA config used the same certificate name for multiple account or OUs. Will ow display a warning if this occurs