### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - main
 env: 
   NODE_OPTIONS: "--max-old-space-size=28000"
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
 
 name: Merge Release Branch
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
   push:
     branches:
       - "release/v*"
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release:
     name: Create Release


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.