### PR TITLE
fix(drift-detection): output DELETED resources in consolidated csv drift file

### DIFF
--- a/reference-artifacts/Custom-Scripts/lza-upgrade/src/resource-mapping.ts
+++ b/reference-artifacts/Custom-Scripts/lza-upgrade/src/resource-mapping.ts
@@ -444,7 +444,7 @@ export class ResourceMapping {
     const resourceFilePath = s3Prefix;
     const resourceFileCSV = this.convertToCSV(resourceMap);
     for (const resource of driftDetectionResources) {
-      if (resource.DriftStatus === 'MODIFIED') {
+      if (resource.DriftStatus === 'MODIFIED' || resource.DriftStatus === 'DELETED') {
         this.driftedResources.push({
           Account: accountId,
           Region: region,


### PR DESCRIPTION

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

When building the consolidated `AllDriftDetectedResources.csv` file, resources that are in status `DELETED` from ASEA CloudFormation stacks were not included. This PR now includes `MODIFIED` and `DELETED` resources in `AllDriftDetectedResources.csv`